### PR TITLE
custom_properties 내 프로퍼티 WindowManager로 옮기기

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -42,6 +42,10 @@ class AconWindowManagerProperty(bpy.types.PropertyGroup):
         update=scenes.load_scene,
     )
 
+    show_guide: bpy.props.BoolProperty(
+        name="Show Guide", default=True, update=remember_show_guide
+    )
+
 
 class CollectionLayerExcludeProperties(bpy.types.PropertyGroup):
     @classmethod
@@ -542,10 +546,6 @@ class AconMeshProperty(bpy.types.PropertyGroup):
     login_status: bpy.props.StringProperty(
         name="Login Status",
         description="Login Status",
-    )
-
-    show_guide: bpy.props.BoolProperty(
-        name="Show Guide", default=True, update=remember_show_guide
     )
 
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -75,8 +75,7 @@ class AconTutorialGuidePopUpOperator(bpy.types.Operator):
     bl_translation_context = "*"
 
     def execute(self, context):
-        userInfo = bpy.data.meshes.get("ACON_userInfo")
-        prop = userInfo.ACON_prop
+        prop = context.window_manager.ACON_prop
         prop.show_guide = read_remembered_show_guide()
 
         bpy.ops.wm.splash_tutorial_1("INVOKE_DEFAULT")

--- a/release/scripts/startup/abler/lib/read_cookies.py
+++ b/release/scripts/startup/abler/lib/read_cookies.py
@@ -31,8 +31,7 @@ def read_remembered_checkbox() -> bool:
 
 
 def remember_show_guide(self, context) -> None:
-    userInfo = bpy.data.meshes.get("ACON_userInfo")
-    prop = userInfo.ACON_prop
+    prop = context.window_manager.ACON_prop
     with open(path_cookies_tutorial_guide, "wb") as cookies_tutorial_guide:
         pickle.dump(prop.show_guide, cookies_tutorial_guide)
 

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3196,8 +3196,6 @@ class WM_MT_splash_tutorial(Menu):
 
     def draw(self, context):
 
-        userInfo = bpy.data.meshes.get("ACON_userInfo")
-
         layout = self.layout
         layout.operator_context = 'EXEC_DEFAULT'
 
@@ -3223,7 +3221,8 @@ class WM_MT_splash_tutorial(Menu):
 
         column = layout.column()
         row = column.row()
-        row.prop(userInfo.ACON_prop, "show_guide", text="", icon="CHECKBOX_HLT", emboss=False, invert_checkbox=True)
+        prop = context.window_manager.ACON_prop
+        row.prop(prop, "show_guide", text="", icon="CHECKBOX_HLT", emboss=False, invert_checkbox=True)
         row.alignment = "RIGHT"
         row.label(text="Show ABLER Starts")
         layout.separator()

--- a/source/blender/editors/interface/interface_handlers.c
+++ b/source/blender/editors/interface/interface_handlers.c
@@ -544,7 +544,8 @@ static CurveProfile but_copypaste_profile = {0};
 static bool but_copypaste_profile_alive = false;
 
 /** \} */
-const char *SkipIdentifierKeywords[] = {"password", "password_shown", "username", "show_password", "remember_username", "show_guide"};
+const char *SkipIdentifierKeywords[] = {
+    "password", "password_shown", "username", "show_password", "remember_username"};
 /* -------------------------------------------------------------------- */
 /** \name UI Queries
  * \{ */


### PR DESCRIPTION
## 관련 링크
https://acontainer.slack.com/archives/C02K1NPTV42/p1663137556231639

## 발제/내용

- custom_properties에서 정의한 프로퍼티는 .blend 파일에 저정돼 프로퍼티 변경 후 프로그램 종료 시 `Save changes before closing?`문구가 뜹니다.
- 요 이슈를 해결하기 위해 특정 프로퍼티는 interface_handlers.c의 `const char *SkipIdentifierKeywords[]`에서 스킵하고 있습니다.
- WindowManager에 만든 프로퍼티는 .blend에 저장되지 않는다는 제보를 받아 기술 검토 해 보았습니다.

## 대응

### 어떤 조치를 취했나요?

- show_guide 프로퍼티(프로그램 시작 시 튜토리얼 가이드를 띄우는 프로퍼티)를 AconWindowManagerProperty 로 이동 후 `*SkipIdentifierKeywords[]`에서도 해당 프로퍼티 제외한 뒤 실행해도 프로그램 종료 후 문구가 뜨지 않는걸 확인했습니다.
- `*SkipIdentifierKeywords[]`의 나머지 프로퍼티들(`"password"`, `"password_shown"`, `"username"`, `"show_password"`, `"remember_username"`)도 동일한 작업을 진행하면 될거 같습니다.