### PR TITLE
런처로 에이블러를 실행할 때, 콘솔을 실행하지 않기

### DIFF
--- a/launcher_abler/privilege_helper.py
+++ b/launcher_abler/privilege_helper.py
@@ -312,6 +312,17 @@ def runas_shell_user(
             cmd, executable, creationflags, cwd, startupinfo, return_handles
         )
     with enable_privileges(win32security.SE_IMPERSONATE_NAME):
+        # advapi32.CreateProcessWithTokenW()에서 새 프로세스와 기본 스레드를 생성하고,
+        # 해당 함수가 문제가 없으면 AblerLauncher.py > exec_windows()가 실행됨.
+        # 여기에서 매개변수 dwCreationFlags의 플래그 값이 콘솔과 프로세스를 관리하고 있어 이 값을 수정함.
+        #
+        # Docs: advapi32.CreateProcessWithTokenW()
+        # https://learn.microsoft.com/ko-kr/windows/win32/api/winbase/nf-winbase-createprocesswithtokenw
+        #
+        # Docs: dwCreateionFlags
+        # https://learn.microsoft.com/ko-kr/windows/win32/procthread/process-creation-flags
+        creationflags = win32con.CREATE_NO_WINDOW  # 0x08000000
+
         if not advapi32.CreateProcessWithTokenW(
             int(htoken),
             0,


### PR DESCRIPTION
# 기능 테스트 필요함!


## 관련 링크

[에이블러 프로그램 직접 실행 시에 system console 화면이 노출됨](https://www.notion.so/acon3d/system-console-dde7cc83f1c04704927c572b4d57df0e)


## 발제/내용

- `blender.exe` 실행
- System Console이 같이 실행됨
- Blender 프로그램에서도 같은 현상이 발생하고 있음


## 대응

### 어떤 조치를 취했나요?

- `privilege_helper.py` > `runas_shell_user()` > `enable_privileges()` > `advapi32.CreateProcessWithTokenW()` 함수에서 Windows의 새 프로세스와 기본 스레드를 생성하고 관리함 ([CreateProcessWithTokenW()](https://learn.microsoft.com/ko-kr/windows/win32/api/winbase/nf-winbase-createprocesswithtokenw))
- 이 함수가 실행될 때, 문제가 없으면 `exec_windows()` 함수가 실행되고 에이블러가 정상적으로 실행됨.
- `CreateProcessWithTokenW()` 를 호출하면서 매개변수 `dwCreationFlags` 의 값으로 `creationflags` 가 사용되는데, 이 매개변수가 새 프로세스를 실행할 때 콘솔 창을 사용할지 말지 결정할 수 있음. ([프로세스 만들기 플래그](https://learn.microsoft.com/ko-kr/windows/win32/procthread/process-creation-flags))
- 그래서 해당 값을 변경함

### 추가 확인 사항 필요

런처로 에이블러를 실행할 때 콘솔창이 실행되지 않도록 수정하였으나, Blender 3.0 이상의 버전에서 같은 방식으로 동작하는지 확인이 필요함

- [x]  바로가기 > Launch ABLER > Run ABLER
- [x]  `blender.exe` 직접 실행
- [x]  에이블러 파일을 더블 클릭으로 실행
- [x]  에이블러 파일 > 연결 프로그램 > 에이블러 `Blender` 실행