### PR TITLE
SWTASK-39 랜더 할 때 카메라가 없어서 발생하는 문제

### DIFF
--- a/release/scripts/startup/abler/export_tab/export_control.py
+++ b/release/scripts/startup/abler/export_tab/export_control.py
@@ -259,9 +259,8 @@ class Acon3dSnipRenderPanel(bpy.types.Panel):
         layout.label(icon="XRAY")
 
     def draw(self, context):
-        if bpy.context.scene.camera:
-            scene = context.scene
-
+        scene = context.scene
+        if scene.camera:
             layout = self.layout
             row = layout.row(align=True)
             row.use_property_split = True

--- a/release/scripts/startup/abler/export_tab/export_control.py
+++ b/release/scripts/startup/abler/export_tab/export_control.py
@@ -228,17 +228,18 @@ class Acon3dQuickRenderPanel(bpy.types.Panel):
         layout.label(icon="RESTRICT_RENDER_OFF")
 
     def draw(self, context):
-        scene = context.scene
+        if bpy.context.scene.camera:
+            scene = context.scene
 
-        layout = self.layout
-        row = layout.row(align=True)
-        row.use_property_split = True
-        row.use_property_decorate = False
-        row.operator("acon3d.camera_view", text="", icon="RESTRICT_VIEW_OFF")
-        row.prop(scene.render, "resolution_x", text="")
-        row.prop(scene.render, "resolution_y", text="")
-        row = layout.row()
-        row.operator("acon3d.render_quick", text="Render Viewport")
+            layout = self.layout
+            row = layout.row(align=True)
+            row.use_property_split = True
+            row.use_property_decorate = False
+            row.operator("acon3d.camera_view", text="", icon="RESTRICT_VIEW_OFF")
+            row.prop(scene.render, "resolution_x", text="")
+            row.prop(scene.render, "resolution_y", text="")
+            row = layout.row()
+            row.operator("acon3d.render_quick", text="Render Viewport")
 
 
 class Acon3dSnipRenderPanel(bpy.types.Panel):
@@ -258,17 +259,18 @@ class Acon3dSnipRenderPanel(bpy.types.Panel):
         layout.label(icon="XRAY")
 
     def draw(self, context):
-        scene = context.scene
+        if bpy.context.scene.camera:
+            scene = context.scene
 
-        layout = self.layout
-        row = layout.row(align=True)
-        row.use_property_split = True
-        row.use_property_decorate = False
-        row.operator("acon3d.camera_view", text="", icon="RESTRICT_VIEW_OFF")
-        row.prop(scene.render, "resolution_x", text="")
-        row.prop(scene.render, "resolution_y", text="")
-        row = layout.row()
-        row.operator("acon3d.render_snip", text="Render Viewport")
+            layout = self.layout
+            row = layout.row(align=True)
+            row.use_property_split = True
+            row.use_property_decorate = False
+            row.operator("acon3d.camera_view", text="", icon="RESTRICT_VIEW_OFF")
+            row.prop(scene.render, "resolution_x", text="")
+            row.prop(scene.render, "resolution_y", text="")
+            row = layout.row()
+            row.operator("acon3d.render_snip", text="Render Viewport")
 
 
 classes = (

--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -54,7 +54,11 @@ def setup_background_images_compositor(node_left=None, node_right=None, scene=No
     tree = scene.node_tree
     nodes = tree.nodes
 
-    cam = scene.camera.data
+    if not scene.camer.data:
+        return
+    else:
+        cam = scene.camera.data
+
     background_images = cam.background_images
     toggle_texture = context.scene.ACON_prop.toggle_texture
 

--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -54,7 +54,7 @@ def setup_background_images_compositor(node_left=None, node_right=None, scene=No
     tree = scene.node_tree
     nodes = tree.nodes
 
-    if not scene.camer.data:
+    if not scene.camera.data:
         return
     else:
         cam = scene.camera.data


### PR DESCRIPTION
## 관련 링크
[카메라가 없을 때 Quick Render 에러 발생-태스크 카드](https://www.notion.so/acon3d/Quick-Render-2db84d5e85634219ac3c179003b7dc28)

## 발제/내용
- 카메라가 없을 때 Quick Render 에서 에러가 발생함

## 대응
- 세가지 랜더에 모두 카메라 여부 확인하는 if문 추가

### 어떤 조치를 취했나요?
- 세가지 랜더에 모두 카메라 여부 확인하는 if문 추가