### PR TITLE
SWTASK-38 오브젝트안에 프로퍼티가 존재하지 않을 경우를 방지하지 않아 생긴 문제

### DIFF
--- a/release/scripts/startup/abler/lib/file_view.py
+++ b/release/scripts/startup/abler/lib/file_view.py
@@ -9,12 +9,12 @@ def file_view_title(title_enum):
     """
     # set_fileselect_title가 없어서 발생하는 에러로 인해 if문 추가
     # 해당 이슈 링크: https://www.notion.so/acon3d/file_view_title-set_fileselect_title-98b55d3116f942f69759f0d63dd7be35?pvs=4
-    if bpy.context.window_manager.set_fileselect_title:
-        bpy.context.window_manager.set_fileselect_title(title_enum=title_enum)
+    if set_fileselect_title := bpy.context.window_manager.set_fileselect_title:
+        set_fileselect_title(title_enum=title_enum)
         yield
         # 바로 기본값으로 되돌리면 위쪽 변경사항이 반영되지 않은 채 파일 다이얼로그가 나타나는 문제가 있어서, 한 틱 뒤에 원상복구
         bpy.app.timers.register(
-            lambda: bpy.context.window_manager.set_fileselect_title(
+            lambda: set_fileselect_title(
                 title_enum="DEFAULT"
             )
         )

--- a/release/scripts/startup/abler/lib/file_view.py
+++ b/release/scripts/startup/abler/lib/file_view.py
@@ -7,6 +7,8 @@ def file_view_title(title_enum):
     """
     :param title_enum: WM_types.h 의 abler_fileViewTitle 참고
     """
+    # set_fileselect_title가 없어서 발생하는 에러로 인해 if문 추가
+    # 해당 이슈 링크: https://www.notion.so/acon3d/file_view_title-set_fileselect_title-98b55d3116f942f69759f0d63dd7be35?pvs=4
     if bpy.context.window_manager.set_fileselect_title:
         bpy.context.window_manager.set_fileselect_title(title_enum=title_enum)
         yield

--- a/release/scripts/startup/abler/lib/file_view.py
+++ b/release/scripts/startup/abler/lib/file_view.py
@@ -7,9 +7,12 @@ def file_view_title(title_enum):
     """
     :param title_enum: WM_types.h 의 abler_fileViewTitle 참고
     """
-    bpy.context.window_manager.set_fileselect_title(title_enum=title_enum)
-    yield
-    # 바로 기본값으로 되돌리면 위쪽 변경사항이 반영되지 않은 채 파일 다이얼로그가 나타나는 문제가 있어서, 한 틱 뒤에 원상복구
-    bpy.app.timers.register(
-        lambda: bpy.context.window_manager.set_fileselect_title(title_enum="DEFAULT")
-    )
+    if bpy.context.window_manager.set_fileselect_title:
+        bpy.context.window_manager.set_fileselect_title(title_enum=title_enum)
+        yield
+        # 바로 기본값으로 되돌리면 위쪽 변경사항이 반영되지 않은 채 파일 다이얼로그가 나타나는 문제가 있어서, 한 틱 뒤에 원상복구
+        bpy.app.timers.register(
+            lambda: bpy.context.window_manager.set_fileselect_title(
+                title_enum="DEFAULT"
+            )
+        )

--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -54,11 +54,7 @@ def setup_background_images_compositor(node_left=None, node_right=None, scene=No
     tree = scene.node_tree
     nodes = tree.nodes
 
-    if not scene.camer.data:
-        return
-    else:
-        cam = scene.camera.data
-
+    cam = scene.camera.data
     background_images = cam.background_images
     toggle_texture = context.scene.ACON_prop.toggle_texture
 

--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -54,7 +54,11 @@ def setup_background_images_compositor(node_left=None, node_right=None, scene=No
     tree = scene.node_tree
     nodes = tree.nodes
 
-    cam = scene.camera.data
+    if not scene.camer.data:
+        return
+    else:
+        cam = scene.camera.data
+
     background_images = cam.background_images
     toggle_texture = context.scene.ACON_prop.toggle_texture
 


### PR DESCRIPTION
## 관련 링크
[file_view_title에서 set_fileselect_title이 없는 에러-테스크 카드](https://www.notion.so/acon3d/file_view_title-set_fileselect_title-98b55d3116f942f69759f0d63dd7be35)

## 발제/내용
- file_view.py에서 window_manager에 set_fileselect_title이 없어서 에러 발생

## 대응
- `file_view_title()`에서 `bpy.context.window_manager.set_fileselect_title`를 확인해줘야 함.

### 어떤 조치를 취했나요?
- `bpy.context.window_manager.set_fileselect_title`를 확인하는 if문 추가