### PR TITLE
오브젝트가 없거나 선택되지 않았을 때 그룹 네비게이션을 사용하면서 발생하는 문제

### DIFF
--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -96,19 +96,27 @@ class GroupNavigationManager:
                         select_active_and_descendants()
 
     def go_down(self):
-        if len(self._selection_undo_stack) > 0:
-            with self._programmatic_selection_scope():
-                last_selected = self._selection_undo_stack.pop()
-                bpy.context.view_layer.objects.active = last_selected
-                select_active_and_descendants()
+        obj = bpy.context.active_object
+        if obj:
+            if parent := obj.parent:
+                if parent.parent is not None:
+                    if len(self._selection_undo_stack) > 0:
+                        with self._programmatic_selection_scope():
+                            last_selected = self._selection_undo_stack.pop()
+                            bpy.context.view_layer.objects.active = last_selected
+                            select_active_and_descendants()
 
     def go_bottom(self):
-        if len(self._selection_undo_stack) > 0:
-            with self._programmatic_selection_scope():
-                while len(self._selection_undo_stack) > 0:
-                    last_selected = self._selection_undo_stack.pop()
-                bpy.context.view_layer.objects.active = last_selected
-                select_active_and_descendants()
+        obj = bpy.context.active_object
+        if obj:
+            if parent := obj.parent:
+                if parent.parent is not None:
+                    if len(self._selection_undo_stack) > 0:
+                        with self._programmatic_selection_scope():
+                            while len(self._selection_undo_stack) > 0:
+                                last_selected = self._selection_undo_stack.pop()
+                            bpy.context.view_layer.objects.active = last_selected
+                            select_active_and_descendants()
 
     def _programmatic_selection_scope(self):
         return ProgrammaticSelectionScope(self)

--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -76,8 +76,8 @@ class GroupNavigationManager:
 
     def go_top(self):
         obj = bpy.context.active_object
-        if obj.parent:
-            while obj.parent.parent:
+        if parent := obj.parent:
+            if parent.parent is not None:
                 self._selection_undo_stack.append(obj)
                 obj = obj.parent
         with self._programmatic_selection_scope():

--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -76,22 +76,24 @@ class GroupNavigationManager:
 
     def go_top(self):
         obj = bpy.context.active_object
-        if parent := obj.parent:
-            if parent.parent is not None:
-                self._selection_undo_stack.append(obj)
-                obj = obj.parent
-        with self._programmatic_selection_scope():
-            bpy.context.view_layer.objects.active = obj
-            select_active_and_descendants()
+        if obj:
+            if parent := obj.parent:
+                if parent.parent is not None:
+                    self._selection_undo_stack.append(obj)
+                    obj = obj.parent
+            with self._programmatic_selection_scope():
+                bpy.context.view_layer.objects.active = obj
+                select_active_and_descendants()
 
     def go_up(self):
         obj = bpy.context.active_object
-        if parent := obj.parent:
-            if parent.parent is not None:
-                with self._programmatic_selection_scope():
-                    self._selection_undo_stack.append(obj)
-                    bpy.context.view_layer.objects.active = parent
-                    select_active_and_descendants()
+        if obj:
+            if parent := obj.parent:
+                if parent.parent is not None:
+                    with self._programmatic_selection_scope():
+                        self._selection_undo_stack.append(obj)
+                        bpy.context.view_layer.objects.active = parent
+                        select_active_and_descendants()
 
     def go_down(self):
         if len(self._selection_undo_stack) > 0:

--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -78,7 +78,7 @@ class GroupNavigationManager:
         obj = bpy.context.active_object
         if obj:
             if parent := obj.parent:
-                if parent.parent is not None:
+                while parent.parent:
                     self._selection_undo_stack.append(obj)
                     obj = obj.parent
             with self._programmatic_selection_scope():


### PR DESCRIPTION
## 관련 링크
[Group Navigation 에서 선택된 개체가 없을 때 go_top 에러 발생 - 에러카드](https://www.notion.so/acon3d/Group-Navigation-go_top-f5f6b128c437483cabf2e228b00e8f6a)
[active_object가 없을 때 그룹네비게이션 parent 에러- 에러카드](https://www.notion.so/acon3d/active_object-parent-8382b758e6a84490a6f46d1973253f7a)

## 발제/내용
- 오브젝트가 없거나 선택되지 않았을 때 그룹 네비게이션을 사용하면서 발생하는 문제

## 대응

### 어떤 조치를 취했나요?

- obj가 none인지 확인하는 if문과 go_up과 go_top의 if문 조건을 동일하게 맞췄습니다. 