### PR TITLE
SWTASK-32 load_scene_by_index 함수에서 active_scene이 없어서 발생하는 문제

### DIFF
--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -140,7 +140,10 @@ def load_scene_by_index(self, context: Context) -> None:
     active_scene_index = self.active_scene_index
 
     # EnumProperty인 self.scene을 select scene으로 변경
-    self.scene = scene_col[active_scene_index].name
+    if not active_scene_index:
+        pass
+    else:
+        self.scene = scene_col[active_scene_index].name
     load_scene(self, context)
 
 

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -140,7 +140,9 @@ def load_scene_by_index(self, context: Context) -> None:
     active_scene_index = self.active_scene_index
 
     # EnumProperty인 self.scene을 select scene으로 변경
-    if not active_scene_index:
+    if len(scene_col) <= active_scene_index:
+        pass
+    elif active_scene_index<0:
         pass
     else:
         self.scene = scene_col[active_scene_index].name

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -142,7 +142,7 @@ def load_scene_by_index(self, context: Context) -> None:
     # EnumProperty인 self.scene을 select scene으로 변경
     if len(scene_col) <= active_scene_index:
         pass
-    elif active_scene_index<0:
+    elif active_scene_index < 0:
         pass
     else:
         self.scene = scene_col[active_scene_index].name


### PR DESCRIPTION
## 관련 링크
[활성화 된 씬이 없는데 접근하는 문제-노션 카드](https://www.notion.so/acon3d/86ba61de6ef14e0fb236fe0425584db1?pvs=4)
[활성화 된 씬이 없는데 접근하는 문제-Jira 테스크](https://carpenstreet.atlassian.net/browse/SWTASK-32?focusedCommentId=14073&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14073)

## 발제/내용
- 활성화 된 씬이 없어서 에러 발생

## 대응

### 어떤 조치를 취했나요?
- 활성화 된 씬이 없다는 건 `active_scene_index`가 없다는 것이 되므로 확인하는 `if문` 추가