### PR TITLE
SWTASK-67 grid_on_when_selected 에서 selected_objects 가 없을 때 에러 발생

### DIFF
--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -129,9 +129,9 @@ def save_post_handler(dummy):
 
 @persistent
 def grid_on_when_selected(dummy):
-    if len(bpy.context.selected_objects) is None:
-        return
-    show_grid = len(bpy.context.selected_objects) > 0
+    show_grid = False
+    if bpy.context.selected_objects is not None and len(bpy.context.selected_objects) > 0:
+        show_grid = True
     if find_screen_acon3d():
         viewport_overlay = bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay
         viewport_overlay.show_ortho_grid = show_grid

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -129,7 +129,7 @@ def save_post_handler(dummy):
 
 @persistent
 def grid_on_when_selected(dummy):
-    if not bpy.context.selected_objects:
+    if len(bpy.context.selected_objects) is None:
         return
     show_grid = len(bpy.context.selected_objects) > 0
     if find_screen_acon3d():

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -129,8 +129,9 @@ def save_post_handler(dummy):
 
 @persistent
 def grid_on_when_selected(dummy):
-    if selected_objects := bpy.context.selected_objects:
-        show_grid = len(selected_objects) > 0
+    if not bpy.context.selected_objects:
+        pass
+    show_grid = len(bpy.context.selected_objects) > 0
     if find_screen_acon3d():
         viewport_overlay = bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay
         viewport_overlay.show_ortho_grid = show_grid

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -130,7 +130,7 @@ def save_post_handler(dummy):
 @persistent
 def grid_on_when_selected(dummy):
     if not bpy.context.selected_objects:
-        pass
+        return
     show_grid = len(bpy.context.selected_objects) > 0
     if find_screen_acon3d():
         viewport_overlay = bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay


### PR DESCRIPTION
## 관련 링크
[grid_on_when_selected 에서 selected_objects 가 없을 때 에러 발생 -Jira 카드](https://carpenstreet.atlassian.net/browse/SWTASK-67)

## 발제/내용
- 기존에 바꾼 코드에서 `show_grid`라는 boolean값이 if문 안에서 정의되어 에러가 발생함
<img width="795" alt="Screenshot 2023-02-21 at 3 23 37 PM" src="https://user-images.githubusercontent.com/76549884/220269192-7e4fab13-f91b-426a-9d27-24f35936b2df.png">


## 대응

### 어떤 조치를 취했나요?
- `show_grid`정의 하는 부분을 if문 밖으로 수정함