### PR TITLE
SWTASK-49 Look At Me 기능을 사용할 때 Recursion Error발생

### DIFF
--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -37,8 +37,9 @@ def add_group_list_from_collection(
 
 def set_constraint_to_camera_by_object(obj, context=None):
 
-    # 2147483647는 C에서 max int 값
-    sys.setrecursionlimit(2147483647)
+    # 이것은 C의 최대 int값이다
+    MAX_C_INT = 2147483647
+    sys.setrecursionlimit(MAX_C_INT)
 
     if not context:
         context = bpy.context

--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Any, Dict, List, Union, Tuple, Optional
 from bpy.types import Context
 import bpy
@@ -35,6 +36,8 @@ def add_group_list_from_collection(
 
 
 def set_constraint_to_camera_by_object(obj, context=None):
+
+    sys.setrecursionlimit(2147483647)
 
     if not context:
         context = bpy.context

--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -37,6 +37,7 @@ def add_group_list_from_collection(
 
 def set_constraint_to_camera_by_object(obj, context=None):
 
+    # 2147483647는 C에서 max int 값
     sys.setrecursionlimit(2147483647)
 
     if not context:


### PR DESCRIPTION
## 관련 링크
[Look At Me 기능을 사용할 때, Python의 최대 재귀 깊이를 초과해서 에러 발생 - Jira 티켓](https://carpenstreet.atlassian.net/browse/SWTASK-49)

## 발제/내용
- 한번에 많은 개체들에게 `Look at me`를 적용하면 Python recursion limit을 초과해서 Recursion Error가 발생함.

## 대응

### 어떤 조치를 취했나요?
- `sys.setrecursionlimit()`을 이용해 recursion limit을 C의 max int 값인 `2147483647`으로 설정함.
- 하지만, 아직도 Look at me를 실행하면 터지는 에러가 발생해 새로운 Error 티켓을 만들것임.