### PR TITLE
SWTASK-105 slot.material.node_tree가 None인 에러 발생

### DIFF
--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -207,6 +207,10 @@ class MATERIAL_UL_List(bpy.types.UIList):
             layout.prop(ma, "name", text="", emboss=False, icon_value=icon)
             layout.prop(ma.ACON_prop, "type", text="")
 
+            # exception handling code added due to error from link below
+            # https://carpenstreet-np.sentry.io/issues/3974831978/?project=4504597190803456&referrer=slack
+            if not ma.node_tree:
+                return
             toonNode = ma.node_tree.nodes.get("ACON_nodeGroup_combinedToon")
 
             if not toonNode:


### PR DESCRIPTION
## 관련 링크
[에러 링크](https://carpenstreet-np.sentry.io/issues/3974831978/?project=4504597190803456&referrer=slack)
[Jira 티켓 링크](https://carpenstreet.atlassian.net/browse/SWTASK-105?atlOrigin=eyJpIjoiYTg5MDIxNTBlZmFjNDJkOWJhN2ViOWUyZTBmNGY2Y2UiLCJwIjoiaiJ9)

## 발제/내용

- `slot.material.node_tree`가 None인 상황에서 에러가 발생했음

## 대응

### 어떤 조치를 취했나요?
- 아래와 같은 코드를 추가하고 해당 내용이 왜 추가되었는지 주석도 추가함.
```python
if not ma.node_tree:
    return
```