### PR TITLE
SWTASK-91 기본 설정값 프리셋 추가

### DIFF
--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -242,6 +242,41 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
 
     prop = new_scene.ACON_prop
 
+    if type == "Default":
+
+        prop.toggle_toon_edge = True
+        prop.edge_min_line_width = 1
+        prop.edge_max_line_width = 1
+        prop.edge_line_detail = 1
+        prop.toggle_toon_face = True
+        prop.toggle_texture = True
+        prop.toggle_shading = True
+        prop.toon_shading_depth = "3"
+        prop.toon_shading_brightness_1 = 3
+        prop.toon_shading_brightness_2 = 5
+        prop.toggle_sun = True
+        prop.sun_strength = 1.5
+        prop.toggle_shadow = True
+        prop.sun_rotation_x = radians(20)
+        prop.sun_rotation_z = radians(130)
+        prop.image_adjust_brightness = 0
+        prop.image_adjust_contrast = 0
+        prop.image_adjust_color_r = 1
+        prop.image_adjust_color_g = 1
+        prop.image_adjust_color_b = 1
+        prop.image_adjust_hue = 0.5
+        prop.image_adjust_saturation = 1
+        prop.use_bloom = True
+        prop.bloom_threshold = 1
+        prop.bloom_knee = 0.5
+        prop.bloom_radius = 4
+        prop.bloom_color = (1, 1, 1)
+        prop.bloom_intensity = 0.5
+        prop.bloom_clamp = 0
+        new_scene.render.resolution_x = 4800
+        new_scene.render.resolution_y = 2700
+
+
     if type == "Indoor Daytime":
 
         prop.toggle_toon_edge = True

--- a/release/scripts/startup/abler/scene_tab/scene_control.py
+++ b/release/scripts/startup/abler/scene_tab/scene_control.py
@@ -72,6 +72,7 @@ class CreateSceneOperator(bpy.types.Operator):
         description="Select scene preset",
         items=[
             ("None", "Use Current Scene Settings", ""),
+            ("Default", "Default", ""),
             ("Indoor Daytime", "Indoor Daytime", ""),
             ("Indoor Sunset", "Indoor Sunset", ""),
             ("Indoor Nighttime", "Indoor Nighttime", ""),


### PR DESCRIPTION
## 관련 링크
[링크](https://carpenstreet.atlassian.net/browse/SWTASK-91)

## 발제/내용

- 에이블러에서 다양한 프리셋이 있지만, 기본 설정값으로 지정된 프리셋이 없음. 오류경험의 일종이므로 생성해야함.

## 대응

### 어떤 조치를 취했나요?

- preset에 default 항목 추가
- default 선택 시 prop 값 설정
- default는 ko.po에 이미 '기본 값'으로 번역되고 있음
<img width="326" alt="스크린샷 2023-03-16 오후 4 25 06" src="https://user-images.githubusercontent.com/87409148/225546326-7f3d8ef3-5263-499a-b206-c2b619537852.png">
<img width="324" alt="스크린샷 2023-03-16 오후 4 25 23" src="https://user-images.githubusercontent.com/87409148/225546455-51efad34-00df-4e7a-b39c-921e74dc44e8.png">
