### PR TITLE
SWTASK-118  scene_col의 scene과 outliner의 scene이 맞지 않아서 발생하는 문제

### DIFF
--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -161,7 +161,10 @@ def change_scene_name(self, context):
 
         scene_col = prop.scene_col
         active_scene_index = prop.active_scene_index
-        bpy.context.scene.name = scene_col[active_scene_index].name
+        if active_scene_index < len(bpy.data.scenes):
+            bpy.context.scene.name = scene_col[active_scene_index].name
+        else:
+            return
 
     is_scene_renamed = True
 

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -161,13 +161,10 @@ def change_scene_name(self, context):
 
         scene_col = prop.scene_col
         active_scene_index = prop.active_scene_index
-        if active_scene_index < len(bpy.data.scenes):
-            bpy.context.scene.name = scene_col[active_scene_index].name
-        else:
-            return
+        bpy.context.scene.name = scene_col[active_scene_index].name
+        add_scene_items_to_collection()
 
     is_scene_renamed = True
-
 
 def add_scene_items(self, context: Context) -> List[Tuple[str, str, str]]:
     scene_items.clear()


### PR DESCRIPTION
## 관련 링크
[Jira 티켓 - 씬 개수를 벗어나는 범위의 씬 index에 접근하는 문제](https://carpenstreet.atlassian.net/browse/SWTASK-118)

## 내용
- 씬 이름을 변경하면서 기존에 저장된 active_scene_index 와 scene_col 의 index 범위가 연동되지 않아서 범위를 벗어난 index에 접근할 때 발생하는 것으로 보임

## 해결 방법
- active_scene_index 를 현재 scene_col 번호에 맞게 업데이트 하면 될 것 같음

## 대응
- add_scene_items_to_collection()이라는 기존에 있던 함수(scene_col과 outliner의 scene들을 맞춰 update해주는 함수)를 추가해줌. 