### PR TITLE
[SWTASK-116] 카메라 선택 없이 배경 이미지 속성에 접근하는 버그

### DIFF
--- a/release/scripts/startup/abler/lib/materials/materials_handler.py
+++ b/release/scripts/startup/abler/lib/materials/materials_handler.py
@@ -106,7 +106,8 @@ def toggle_texture(self, context: Context) -> None:
     texture: BoolProperty = context.scene.ACON_prop.toggle_texture
     textureFactorValue: int = int(not texture)
 
-    if context.scene.camera:
+    camera = context.scene.camera
+    if camera and (type(camera.data) == bpy.types.Camera):
         for image in context.scene.camera.data.background_images:
             image.show_background_image = texture
 


### PR DESCRIPTION
# 내용

- 관련 에러: [Sentry](https://carpenstreet-np.sentry.io/issues/3986664346/?project=4504597190803456&referrer=slack)
- 예상 원인 및 재현
  - 재현 불가
  - 카메라 오브젝트 없이 Mesh 로 배경 이미지 속성에 접근하는 방법을 모르겠음
- 해결 방안
  - `context.scene.camera.data`가 카메라 오브젝트인지 아닌지 확인하는 과정이 필요할 것 같음

## 작업 내용

- 카메라 오브젝트를 선택했을 때만 배경 이미지 속성에 접근할 수 있도록 허용