### PR TITLE
default 씬 설정시 bloom이 기본값으로 돌아가지 않는 에러

### DIFF
--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -303,13 +303,13 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 1.05
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1
-        new_scene.eevee.use_bloom = True
-        new_scene.eevee.bloom_threshold = 2
-        new_scene.eevee.bloom_knee = 0.5
-        new_scene.eevee.bloom_radius = 6.5
-        new_scene.eevee.bloom_color = (1, 1, 1)
-        new_scene.eevee.bloom_intensity = 0.1
-        new_scene.eevee.bloom_clamp = 0
+        prop.use_bloom = True
+        prop.bloom_threshold = 2
+        prop.bloom_knee = 0.5
+        prop.bloom_radius = 6.5
+        prop.bloom_color = (1, 1, 1)
+        prop.bloom_intensity = 0.1
+        prop.bloom_clamp = 0
         new_scene.render.resolution_x = 4800
         new_scene.render.resolution_y = 2700
 
@@ -336,13 +336,13 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 0.9
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1
-        new_scene.eevee.use_bloom = True
-        new_scene.eevee.bloom_threshold = 1
-        new_scene.eevee.bloom_knee = 0.5
-        new_scene.eevee.bloom_radius = 6.5
-        new_scene.eevee.bloom_color = (1, 1, 1)
-        new_scene.eevee.bloom_intensity = 0.5
-        new_scene.eevee.bloom_clamp = 0
+        prop.use_bloom = True
+        prop.bloom_threshold = 1
+        prop.bloom_knee = 0.5
+        prop.bloom_radius = 6.5
+        prop.bloom_color = (1, 1, 1)
+        prop.bloom_intensity = 0.5
+        prop.bloom_clamp = 0
         new_scene.render.resolution_x = 4800
         new_scene.render.resolution_y = 2700
 
@@ -369,13 +369,13 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 0.95
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1
-        new_scene.eevee.use_bloom = True
-        new_scene.eevee.bloom_threshold = 1
-        new_scene.eevee.bloom_knee = 0.5
-        new_scene.eevee.bloom_radius = 6.5
-        new_scene.eevee.bloom_color = (0.9, 0.9, 1)
-        new_scene.eevee.bloom_intensity = 0.5
-        new_scene.eevee.bloom_clamp = 0
+        prop.use_bloom = True
+        prop.bloom_threshold = 1
+        prop.bloom_knee = 0.5
+        prop.bloom_radius = 6.5
+        prop.bloom_color = (0.9, 0.9, 1)
+        prop.bloom_intensity = 0.5
+        prop.bloom_clamp = 0
         new_scene.render.resolution_x = 4800
         new_scene.render.resolution_y = 2700
 
@@ -402,13 +402,13 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 1
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1
-        new_scene.eevee.use_bloom = False
-        new_scene.eevee.bloom_threshold = 1
-        new_scene.eevee.bloom_knee = 0.5
-        new_scene.eevee.bloom_radius = 6.5
-        new_scene.eevee.bloom_color = (1, 1, 1)
-        new_scene.eevee.bloom_intensity = 0.1
-        new_scene.eevee.bloom_clamp = 0
+        prop.use_bloom = False
+        prop.bloom_threshold = 1
+        prop.bloom_knee = 0.5
+        prop.bloom_radius = 6.5
+        prop.bloom_color = (1, 1, 1)
+        prop.bloom_intensity = 0.1
+        prop.bloom_clamp = 0
         new_scene.render.resolution_x = 4800
         new_scene.render.resolution_y = 2700
 
@@ -435,13 +435,13 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 0.9
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1
-        new_scene.eevee.use_bloom = True
-        new_scene.eevee.bloom_threshold = 0.8
-        new_scene.eevee.bloom_knee = 0.5
-        new_scene.eevee.bloom_radius = 6.5
-        new_scene.eevee.bloom_color = (1, 0.9, 0.8)
-        new_scene.eevee.bloom_intensity = 0.5
-        new_scene.eevee.bloom_clamp = 0
+        prop.use_bloom = True
+        prop.bloom_threshold = 0.8
+        prop.bloom_knee = 0.5
+        prop.bloom_radius = 6.5
+        prop.bloom_color = (1, 0.9, 0.8)
+        prop.bloom_intensity = 0.5
+        prop.bloom_clamp = 0
         new_scene.render.resolution_x = 4800
         new_scene.render.resolution_y = 2700
 

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -20,7 +20,7 @@
 from typing import List, Tuple, Optional
 import bpy
 from bpy.types import Scene, Context
-from . import shadow, layers, objects
+from . import shadow, layers, bloom
 from .materials import materials_handler
 from math import radians
 from .tracker import tracker
@@ -203,6 +203,12 @@ def load_scene(self, context: Context) -> None:
     materials_handler.change_image_adjust_color(None, context)
     materials_handler.change_image_adjust_hue(None, context)
     materials_handler.change_image_adjust_saturation(None, context)
+    bloom.change_bloom_threshold(None, context)
+    bloom.change_bloom_knee(None, context)
+    bloom.change_bloom_radius(None, context)
+    bloom.change_bloom_color(None, context)
+    bloom.change_bloom_intensity(None, context)
+    bloom.change_bloom_clamp(None, context)
 
     layers.handle_layer_visibility_on_scene_change(oldScene, newScene)
 


### PR DESCRIPTION
## 관련 링크
[링크](https://carpenstreet.atlassian.net/browse/SWTASK-207)

## 발제/내용

- default 씬 설정 시 bloom이 기본값으로 돌아가지 않음
- 기본 씬에서 bloom 프로퍼티를 변경한 후 "Outdoor Sunset" 같은 항목으로 씬을 변경해도 화면의 프로퍼티는 바뀌는데 UI 프로퍼티는 바뀌고 있지 않음

## 대응

### 어떤 조치를 취했나요?

- `create_scene()`에서 prop의 bloom 프로퍼티를 바꿔줘도 create_scene() 시의 prop은 이전 씬을 바라보고 있음
→ bloom 업데이트 함수를 load_scene에서 직접 실행해줘야함
```
def load_scene()
    (...)
    bloom.change_bloom_threshold(None, context)
    bloom.change_bloom_knee(None, context)
    bloom.change_bloom_radius(None, context)
    bloom.change_bloom_color(None, context)
    bloom.change_bloom_intensity(None, context)
    bloom.change_bloom_clamp(None, context)
```
- (이전 버전에도 있는 버그) 기본 씬에서 bloom 프로퍼티를 변경한 후 "Outdoor Sunset" 같은 항목으로 씬을 변경해도 화면의 프로퍼티는 바뀌는데 UI 프로퍼티는 바뀌고 있지 않음
- new_scene.eevee.bloom_knee = 0.5 이런식으로 eevee의 프로퍼티를 직접 바꾸면 UI의 프로퍼티는 변경되지 않음
→ UI 프로퍼티(prop)도 업데이트 되도록 변경