### PR TITLE
SWTASK-197 add_group_list_from_collection에서 obj가 없는 경우 발생하는 에러

### DIFF
--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -57,13 +57,13 @@ def add_group_list_from_collection(
     if obj:
         icon_str = "OUTLINER_OB_MESH" if obj.type == "MESH" else "OUTLINER_OB_EMPTY"
         items.append((obj.name, obj.name, "", icon_str, 0))
-    if obj.parent:
-        while obj.parent.parent:
-            icon_str = (
-                "OUTLINER_OB_MESH" if obj.parent.type == "MESH" else "OUTLINER_OB_EMPTY"
-            )
-            items.append((obj.parent.name, obj.parent.name, "", icon_str, 0))
-            obj = obj.parent
+        if obj.parent:
+            while obj.parent.parent:
+                icon_str = (
+                    "OUTLINER_OB_MESH" if obj.parent.type == "MESH" else "OUTLINER_OB_EMPTY"
+                )
+                items.append((obj.parent.name, obj.parent.name, "", icon_str, 0))
+                obj = obj.parent
 
     return items
 


### PR DESCRIPTION
## 관련 링크
[add_group_list_from_collection 에서 obj 가 없는 경우 에러 발생- jira 티켓](https://carpenstreet.atlassian.net/browse/SWTASK-197)

## 발제/내용
- obj.parent가 존재하지 않을 경우에 add_group_list_from_collection에서 에러가 발생함

## 대응

### 어떤 조치를 취했나요?
- if obj.parent를 확인하기 전에 if obj를 확인해주어야 하기 때문에 if obj 안으로 넣어줌