### PR TITLE
SWTASK-201 group selection에서 obj의 값이 업데이트 되지 않아 발생하고 있는 에러

### DIFF
--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -80,7 +80,7 @@ class GroupNavigationManager:
         if not obj:
             return
         if obj.parent:
-            while obj.parent.parent:
+            while obj.parent:
                 self._selection_undo_stack.append(obj)
                 obj = obj.parent
         with self._programmatic_selection_scope():
@@ -92,7 +92,7 @@ class GroupNavigationManager:
         if not obj:
             return
         if parent := obj.parent:
-            if parent.parent is not None:
+            if parent.parent:
                 with self._programmatic_selection_scope():
                     self._selection_undo_stack.append(obj)
                     bpy.context.view_layer.objects.active = parent

--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -90,12 +90,11 @@ class GroupNavigationManager:
         obj = bpy.context.active_object
         if not obj:
             return
-        if parent := obj.parent:
-            if parent.parent:
-                with self._programmatic_selection_scope():
-                    self._selection_undo_stack.append(obj)
-                    bpy.context.view_layer.objects.active = parent
-                    select_active_and_descendants()
+        if obj.parent:
+            with self._programmatic_selection_scope():
+                self._selection_undo_stack.append(obj)
+                bpy.context.view_layer.objects.active = obj.parent
+                select_active_and_descendants()
 
     def go_down(self):
         if len(self._selection_undo_stack) > 0:

--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -77,7 +77,7 @@ class GroupNavigationManager:
 
     def go_top(self):
         obj = bpy.context.active_object
-        if obj is None:
+        if not obj:
             return
         if obj.parent:
             while obj.parent.parent:
@@ -89,7 +89,7 @@ class GroupNavigationManager:
 
     def go_up(self):
         obj = bpy.context.active_object
-        if obj is None:
+        if not obj:
             return
         if parent := obj.parent:
             if parent.parent is not None:
@@ -99,27 +99,19 @@ class GroupNavigationManager:
                     select_active_and_descendants()
 
     def go_down(self):
-        obj = bpy.context.active_object
-        if obj:
-            if parent := obj.parent:
-                if parent.parent is not None:
-                    if len(self._selection_undo_stack) > 0:
-                        with self._programmatic_selection_scope():
-                            last_selected = self._selection_undo_stack.pop()
-                            bpy.context.view_layer.objects.active = last_selected
-                            select_active_and_descendants()
+        if len(self._selection_undo_stack) > 0:
+            with self._programmatic_selection_scope():
+                last_selected = self._selection_undo_stack.pop()
+                bpy.context.view_layer.objects.active = last_selected
+                select_active_and_descendants()
 
     def go_bottom(self):
-        obj = bpy.context.active_object
-        if obj:
-            if parent := obj.parent:
-                if parent.parent is not None:
-                    if len(self._selection_undo_stack) > 0:
-                        with self._programmatic_selection_scope():
-                            while len(self._selection_undo_stack) > 0:
-                                last_selected = self._selection_undo_stack.pop()
-                            bpy.context.view_layer.objects.active = last_selected
-                            select_active_and_descendants()
+        if len(self._selection_undo_stack) > 0:
+            with self._programmatic_selection_scope():
+                while len(self._selection_undo_stack) > 0:
+                    last_selected = self._selection_undo_stack.pop()
+                bpy.context.view_layer.objects.active = last_selected
+                select_active_and_descendants()
 
     def _programmatic_selection_scope(self):
         return ProgrammaticSelectionScope(self)

--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -77,24 +77,26 @@ class GroupNavigationManager:
 
     def go_top(self):
         obj = bpy.context.active_object
-        if obj:
-            if parent := obj.parent:
-                while parent.parent:
-                    self._selection_undo_stack.append(obj)
-                    obj = obj.parent
-            with self._programmatic_selection_scope():
-                bpy.context.view_layer.objects.active = obj
-                select_active_and_descendants()
+        if obj is None:
+            return
+        if obj.parent:
+            while obj.parent.parent:
+                self._selection_undo_stack.append(obj)
+                obj = obj.parent
+        with self._programmatic_selection_scope():
+            bpy.context.view_layer.objects.active = obj
+            select_active_and_descendants()
 
     def go_up(self):
         obj = bpy.context.active_object
-        if obj:
-            if parent := obj.parent:
-                if parent.parent is not None:
-                    with self._programmatic_selection_scope():
-                        self._selection_undo_stack.append(obj)
-                        bpy.context.view_layer.objects.active = parent
-                        select_active_and_descendants()
+        if obj is None:
+            return
+        if parent := obj.parent:
+            if parent.parent is not None:
+                with self._programmatic_selection_scope():
+                    self._selection_undo_stack.append(obj)
+                    bpy.context.view_layer.objects.active = parent
+                    select_active_and_descendants()
 
     def go_down(self):
         obj = bpy.context.active_object

--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -79,10 +79,9 @@ class GroupNavigationManager:
         obj = bpy.context.active_object
         if not obj:
             return
-        if obj.parent:
-            while obj.parent:
-                self._selection_undo_stack.append(obj)
-                obj = obj.parent
+        while obj.parent:
+            self._selection_undo_stack.append(obj)
+            obj = obj.parent
         with self._programmatic_selection_scope():
             bpy.context.view_layer.objects.active = obj
             select_active_and_descendants()


### PR DESCRIPTION
## 관련 링크
[그룹 네비게이션에서 type 오류로 인해 생기는 에러 - jira 티켓](https://carpenstreet.atlassian.net/browse/SWTASK-201)

## 발제/내용
- while문 안에서 obj값이 업데이트 되지 않는 버그로 인한 오류임을 확인함.

## 대응

### 어떤 조치를 취했나요?
- 가독성을 위해 기존에 작성되었던 코드([해당 PR](https://github.com/carpenstreet/blender/pull/293) 머지 이전)에서 obj가 없을 때만 return하는 방식이 낫다고 판단하여 go_top()과 go_up()을 수정함
- go_bottom()과 go_down() 함수에서는 obj의 존재 여부를 확인할 필요가 없다고 판단하여 또한 언급된 pr 머지 이전의 형태로 복구함
- 기존 go_up() 함수에서 obj.parent.parent의 존재 여부를 확인하고 있어, 최상위 오브젝트의 child는 go_up() 함수 적용대상이 아닌 버그를 발견하여 if obj.parent만 확인하도록 수정함