### PR TITLE
SWTASK-219 Group Navigation 에서 go_down, go_bottom 이 처음 오브젝트 선택 시 실행되지 않는 문제

### DIFF
--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -75,8 +75,15 @@ class GroupNavigationManager:
     def __repr__(self):
         return repr(self._selection_undo_stack)
 
+    def refresh_stack(self):
+        obj = bpy.context.active_object
+        if obj.parent or obj.children not in self._selection_undo_stack:
+            self._selection_undo_stack = []
+            print(self._selection_undo_stack)
+
     def go_top(self):
         obj = bpy.context.active_object
+        self.refresh_stack()
         if not obj:
             return
         while obj.parent:
@@ -88,6 +95,7 @@ class GroupNavigationManager:
 
     def go_up(self):
         obj = bpy.context.active_object
+        self.refresh_stack()
         if not obj:
             return
         if obj.parent:
@@ -99,6 +107,7 @@ class GroupNavigationManager:
     def go_down(self):
         obj = bpy.context.active_object
         i = 0
+        self.refresh_stack()
         if len(self._selection_undo_stack) > 0:
             with self._programmatic_selection_scope():
                 last_selected = self._selection_undo_stack.pop()
@@ -124,6 +133,7 @@ class GroupNavigationManager:
     def go_bottom(self):
         obj = bpy.context.active_object
         i = 0
+        self.refresh_stack()
         if len(self._selection_undo_stack) > 0:
             with self._programmatic_selection_scope():
                 while len(self._selection_undo_stack) > 0:

--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -77,47 +77,49 @@ class GroupNavigationManager:
 
     def go_top(self):
         obj = bpy.context.active_object
-        if obj:
-            if parent := obj.parent:
-                while parent.parent:
-                    self._selection_undo_stack.append(obj)
-                    obj = obj.parent
-            with self._programmatic_selection_scope():
-                bpy.context.view_layer.objects.active = obj
-                select_active_and_descendants()
+        if not obj:
+            return
+        while obj.parent:
+            self._selection_undo_stack.append(obj)
+            obj = obj.parent
+        with self._programmatic_selection_scope():
+            bpy.context.view_layer.objects.active = obj
+            select_active_and_descendants()
 
     def go_up(self):
         obj = bpy.context.active_object
-        if obj:
-            if parent := obj.parent:
-                if parent.parent is not None:
-                    with self._programmatic_selection_scope():
-                        self._selection_undo_stack.append(obj)
-                        bpy.context.view_layer.objects.active = parent
-                        select_active_and_descendants()
+        if not obj:
+            return
+        if obj.parent:
+            with self._programmatic_selection_scope():
+                self._selection_undo_stack.append(obj)
+                bpy.context.view_layer.objects.active = obj.parent
+                select_active_and_descendants()
 
     def go_down(self):
-        obj = bpy.context.active_object
-        if obj:
-            if parent := obj.parent:
-                if parent.parent is not None:
-                    if len(self._selection_undo_stack) > 0:
-                        with self._programmatic_selection_scope():
-                            last_selected = self._selection_undo_stack.pop()
-                            bpy.context.view_layer.objects.active = last_selected
-                            select_active_and_descendants()
+        if len(self._selection_undo_stack) > 0:
+            with self._programmatic_selection_scope():
+                last_selected = self._selection_undo_stack.pop()
+                bpy.context.view_layer.objects.active = last_selected
+                select_active_and_descendants()
+        else:
+            bpy.ops.acon3d.alert(
+                "INVOKE_DEFAULT",
+                title="This is the bottom object",
+            )
 
     def go_bottom(self):
-        obj = bpy.context.active_object
-        if obj:
-            if parent := obj.parent:
-                if parent.parent is not None:
-                    if len(self._selection_undo_stack) > 0:
-                        with self._programmatic_selection_scope():
-                            while len(self._selection_undo_stack) > 0:
-                                last_selected = self._selection_undo_stack.pop()
-                            bpy.context.view_layer.objects.active = last_selected
-                            select_active_and_descendants()
+        if len(self._selection_undo_stack) > 0:
+            with self._programmatic_selection_scope():
+                while len(self._selection_undo_stack) > 0:
+                    last_selected = self._selection_undo_stack.pop()
+                bpy.context.view_layer.objects.active = last_selected
+                select_active_and_descendants()
+        else:
+            bpy.ops.acon3d.alert(
+                "INVOKE_DEFAULT",
+                title="This is the bottom object",
+            )
 
     def _programmatic_selection_scope(self):
         return ProgrammaticSelectionScope(self)

--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -97,18 +97,33 @@ class GroupNavigationManager:
                 select_active_and_descendants()
 
     def go_down(self):
+        obj = bpy.context.active_object
+        i = 0
         if len(self._selection_undo_stack) > 0:
             with self._programmatic_selection_scope():
                 last_selected = self._selection_undo_stack.pop()
                 bpy.context.view_layer.objects.active = last_selected
                 select_active_and_descendants()
         else:
-            bpy.ops.acon3d.alert(
-                "INVOKE_DEFAULT",
-                title="This is the bottom object",
-            )
+            if len(self._selection_undo_stack) == 0:
+                if len(obj.children) > 0:
+                    if i < len(obj.children):
+                        with self._programmatic_selection_scope():
+                            self._selection_undo_stack.append(obj.children[i])
+                            bpy.context.view_layer.objects.active = obj.children[i]
+                            select_active_and_descendants()
+                            i += 1
+                else:
+
+                    bpy.ops.acon3d.alert(
+                        "INVOKE_DEFAULT",
+                        title="This is the bottom object",
+                    )
+
 
     def go_bottom(self):
+        obj = bpy.context.active_object
+        i = 0
         if len(self._selection_undo_stack) > 0:
             with self._programmatic_selection_scope():
                 while len(self._selection_undo_stack) > 0:
@@ -116,10 +131,19 @@ class GroupNavigationManager:
                 bpy.context.view_layer.objects.active = last_selected
                 select_active_and_descendants()
         else:
-            bpy.ops.acon3d.alert(
-                "INVOKE_DEFAULT",
-                title="This is the bottom object",
-            )
+            if len(self._selection_undo_stack) == 0:
+                if len(obj.children) > 0:
+                    with self._programmatic_selection_scope():
+                        if i < len(obj.children):
+                            with self._programmatic_selection_scope():
+                                self._selection_undo_stack.append(obj.children[i])
+                        bpy.context.view_layer.objects.active = obj.children[-1]
+                        select_active_and_descendants()
+                else:
+                    bpy.ops.acon3d.alert(
+                        "INVOKE_DEFAULT",
+                        title="This is the bottom object",
+                    )
 
     def _programmatic_selection_scope(self):
         return ProgrammaticSelectionScope(self)


### PR DESCRIPTION
## 관련 링크
[관련 지라 티켓](https://carpenstreet.atlassian.net/browse/SWTASK-219)

## 발제/내용
- 처음 오브젝트를 선택했을 때 그 오브젝트가 children이 있는경우에도 go_down이나 go_bottom이 작동하지 않음

## 대응

### 어떤 조치를 취했나요?
- 처음 오브젝트를 클릭했을 때에도 go_down과 go_bottom이 적용되게 함.
- 또한 refresh_stack()이라는 함수로 클릭한 obj와 관련이 없는 것들이 stack에 있다면 stack을 초기화 함