### PR TITLE
SWTASK-223 macOS 에이블러 파일 뷰에서 한글 자모 깨지는 현상 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ release/scripts/addons_abler/io_skp
 /launcher_abler/res_rc.py
 /launcher_venv
 /cmake-build-debug
+/cmake-build-debug-visual-studio
+/cmake-build-release-visual-studio

--- a/source/blender/blenfont/intern/blf_font.c
+++ b/source/blender/blenfont/intern/blf_font.c
@@ -458,8 +458,13 @@ static void blf_font_draw_ex(FontBLF *font,
   }
 
   blf_batch_draw_begin(font);
+#ifndef _WIN32
   unsigned int unicode_array[str_len];
+#endif
   while ((i < str_len) && str[i]) {
+#ifdef _WIN32
+    g = blf_utf8_next_fast(font, gc, str, str_len, &i, &c);
+#else
     unsigned int charcode = BLI_str_utf8_as_unicode_step(str, str_len, &i);
     BLI_assert(charcode != BLI_UTF8_ERR);
     unicode_array[index] = charcode;
@@ -478,6 +483,7 @@ static void blf_font_draw_ex(FontBLF *font,
       g = blf_glyph_add(font, gc, FT_Get_Char_Index(font->face, c), c);
     }
     i++;
+#endif
     if (UNLIKELY(c == BLI_UTF8_ERR)) {
       break;
     }

--- a/source/blender/blenfont/intern/blf_font.c
+++ b/source/blender/blenfont/intern/blf_font.c
@@ -458,39 +458,40 @@ static void blf_font_draw_ex(FontBLF *font,
   }
 
   blf_batch_draw_begin(font);
-  uint strstr[str_len];
+  unsigned int unicode_array[str_len];
   while ((i < str_len) && str[i]) {
-    uint charcode = BLI_str_utf8_as_unicode_step(str, str_len, &i);
+    unsigned int charcode = BLI_str_utf8_as_unicode_step(str, str_len, &i);
     BLI_assert(charcode != BLI_UTF8_ERR);
-    strstr[index] = charcode;
+    unicode_array[index] = charcode;
     index++;
   }
-  strstr[index] = 0;
+  unicode_array[index] = 0;
   index = 0;
   i = 0;
-  uint str_new[str_len];
-  join_jamos(strstr, str_new);
+  unsigned int filtered_str[str_len];
+  join_jamos(unicode_array, filtered_str);
 
-  while ((i < str_len) && str_new[i]) {
-    g = blf_glyph_search(gc, str_new[i]);
+  while ((i < str_len) && filtered_str[i]) {
+    c = filtered_str[i];
+    g = blf_glyph_search(gc, c);
     if (UNLIKELY(g == NULL)) {
-      g = blf_glyph_add(font, gc, FT_Get_Char_Index(font->face, str_new[i]), str_new[i]);
+      g = blf_glyph_add(font, gc, FT_Get_Char_Index(font->face, c), c);
     }
     i++;
-    if (UNLIKELY(str_new[i] == BLI_UTF8_ERR)) {
+    if (UNLIKELY(c == BLI_UTF8_ERR)) {
       break;
     }
     if (UNLIKELY(g == NULL)) {
       continue;
     }
-    blf_kerning_step_fast(font, g_prev, g, c_prev, str_new[i], &pen_x);
+    blf_kerning_step_fast(font, g_prev, g, c_prev, c, &pen_x);
 
     /* do not return this loop if clipped, we want every character tested */
     blf_glyph_render(font, gc, g, (float)pen_x, (float)pen_y);
 
     pen_x += g->advance_i;
     g_prev = g;
-    c_prev = str_new[i];
+    c_prev = c;
   }
 
   blf_batch_draw_end();


### PR DESCRIPTION
## 관련 링크
[Jira 티켓 링크](https://carpenstreet.atlassian.net/browse/SWTASK-223?atlOrigin=eyJpIjoiODMwNTZkYzI2ODg3NDYxZGEyZDU4YmQ3YTBmNGYyNDUiLCJwIjoiaiJ9)

## 발제/내용

- macOS에서 에이블러 한글 자모 깨지는 현상이 있음 (파일 뷰어에서만 그럼)

## 대응

### 어떤 조치를 취했나요?

- `blf_font_draw_ex` 함수에서 string들에 대한 while 문을 도는데, 이때 자모를 합칠 수 있는 케이스를 미리 선별해서 합친 문자의 unicode로 새로운 unsigned int array를 채워줌.

## 유의사항
- 나름 큰 변경사항이다보니 모든 피드백을 다 받아들이겠습니다. 빡시게 코멘트 해주세요
- 윈도우 컴이 있으신 분들은 윈도우에서 한번 빌드하여 확인 해봐주시면 감사하겠습니다.
- 쌍자음에 대해서 macOS에서는 잘 적용된 것을 확인하였습니다. 혹시 모르니 더블체크 부탁드리겠습니다.