### PR TITLE
SWTASK-259 Updater 메모리 해제하는 로직 추가

### DIFF
--- a/intern/ghost/GHOST_ISystem.h
+++ b/intern/ghost/GHOST_ISystem.h
@@ -157,6 +157,8 @@ class GHOST_ISystem {
 #if defined(__APPLE__)
   void createUpdater();
 
+  void disposeUpdater();
+
   void checkForUpdates();
 #endif
 

--- a/intern/ghost/intern/GHOST_ISystem.cpp
+++ b/intern/ghost/intern/GHOST_ISystem.cpp
@@ -93,6 +93,10 @@ GHOST_TSuccess GHOST_ISystem::disposeSystem()
 {
   GHOST_TSuccess success = GHOST_kSuccess;
   if (m_system) {
+#if defined(__APPLE__)
+    m_system->disposeUpdater();
+#endif
+
     delete m_system;
     m_system = NULL;
   }
@@ -115,6 +119,13 @@ void GHOST_ISystem::createUpdater()
   {
     updater = new SparkleUpdater();
   }
+}
+
+// ABLER: Updater for MacOS
+void GHOST_ISystem::disposeUpdater()
+{
+  delete updater;
+  updater = NULL;
 }
 
 // ABLER: Updater for MacOS

--- a/intern/ghost/intern/GHOST_SparkleUpdater.mm
+++ b/intern/ghost/intern/GHOST_SparkleUpdater.mm
@@ -3,7 +3,7 @@
 #include "Sparkle/SPUUpdater.h"
 #include "Sparkle/SPUStandardUpdaterController.h"
 
-SPUUpdater *spuUpdater;
+SPUUpdater *spuUpdater = nil;
 
 @interface SparkleDelegate : NSObject <SPUUpdaterDelegate> {
 }
@@ -29,6 +29,7 @@ SparkleUpdater::SparkleUpdater() {
 }
 
 SparkleUpdater::~SparkleUpdater() {
+  [spuUpdater release];
   spuUpdater = nil;
 }
 


### PR DESCRIPTION
## 관련 링크
[이슈](https://carpenstreet.atlassian.net/browse/SWTASK-259?atlOrigin=eyJpIjoiMGZlZWMxNTQ0NTJmNDUxNmFiNmZjMTNlMjg0YjYwMjciLCJwIjoiaiJ9)

## 발제/내용

- Sparkle Updater 등 새로 추가한 Object 들이 system 이 메모리에서 해제될 때 같이 해제되게 한다.ㅋ

## 대응

### 어떤 조치를 취했나요?

- SparkleUpdater 의 소멸자를 추가했습니다.
- GHOST_ISystem 에 disposeUpdater 함수를 만들고 해당 함수를 disposeSystem 시 호출하도록 하였습니다.
