### PR TITLE
SWTASK-251 MacOS 전용 업데이터 변수/함수/클래스 이름 명확하게 수정

### DIFF
--- a/intern/ghost/GHOST_C-api.h
+++ b/intern/ghost/GHOST_C-api.h
@@ -950,7 +950,7 @@ extern void GHOST_EndIME(GHOST_WindowHandle windowhandle);
 
 // ABLER: Updater for MacOS
 #if defined(__APPLE__)
-extern void GHOST_CreateAndCheckUpdater(GHOST_SystemHandle systemhandle);
+extern void GHOST_CreateAndCheckSparkleUpdater(GHOST_SystemHandle systemhandle);
 #endif
 
 #ifdef WITH_XR_OPENXR

--- a/intern/ghost/GHOST_ISystem.h
+++ b/intern/ghost/GHOST_ISystem.h
@@ -153,13 +153,13 @@ class GHOST_ISystem {
    */
   static GHOST_ISystem *getSystem();
 
-    // ABLER: Updater for MacOS
+  // ABLER: Updater for MacOS
 #if defined(__APPLE__)
-  void createUpdater();
+  void createSparkleUpdater();
 
-  void disposeUpdater();
+  void disposeSparkleUpdater();
 
-  void checkForUpdates();
+  void sparkleCheckForUpdates();
 #endif
 
  protected:
@@ -504,7 +504,7 @@ class GHOST_ISystem {
 
   // ABLER: Updater for MacOS
 #if defined(__APPLE__)
-  SparkleUpdater* updater;
+  SparkleUpdater* sparkleUpdater;
 #endif
 
 #ifdef WITH_CXX_GUARDEDALLOC

--- a/intern/ghost/intern/GHOST_C-api.cpp
+++ b/intern/ghost/intern/GHOST_C-api.cpp
@@ -48,12 +48,12 @@ GHOST_SystemHandle GHOST_CreateSystem(void)
 
 // ABLER: Updater for MacOS
 #if defined(__APPLE__)
-void GHOST_CreateAndCheckUpdater(GHOST_SystemHandle systemhandle)
+void GHOST_CreateAndCheckSparkleUpdater(GHOST_SystemHandle systemhandle)
 {
   GHOST_ISystem *system = (GHOST_ISystem *)systemhandle;
 
-  system->createUpdater();
-  system->checkForUpdates();
+  system->createSparkleUpdater();
+  system->sparkleCheckForUpdates();
 }
 #endif
 

--- a/intern/ghost/intern/GHOST_ISystem.cpp
+++ b/intern/ghost/intern/GHOST_ISystem.cpp
@@ -94,7 +94,7 @@ GHOST_TSuccess GHOST_ISystem::disposeSystem()
   GHOST_TSuccess success = GHOST_kSuccess;
   if (m_system) {
 #if defined(__APPLE__)
-    m_system->disposeUpdater();
+    m_system->disposeSparkleUpdater();
 #endif
 
     delete m_system;
@@ -113,24 +113,24 @@ GHOST_ISystem *GHOST_ISystem::getSystem()
 
 // ABLER: Updater for MacOS
 #if defined(__APPLE__)
-void GHOST_ISystem::createUpdater()
+void GHOST_ISystem::createSparkleUpdater()
 {
-  if (updater == NULL)
+  if (sparkleUpdater == NULL)
   {
-    updater = new SparkleUpdater();
+    sparkleUpdater = new SparkleUpdater();
   }
 }
 
 // ABLER: Updater for MacOS
-void GHOST_ISystem::disposeUpdater()
+void GHOST_ISystem::disposeSparkleUpdater()
 {
-  delete updater;
-  updater = NULL;
+  delete sparkleUpdater;
+  sparkleUpdater = NULL;
 }
 
 // ABLER: Updater for MacOS
-void GHOST_ISystem::checkForUpdates()
+void GHOST_ISystem::sparkleCheckForUpdates()
 {
-  updater->checkForUpdates();
+  sparkleUpdater->checkForUpdates();
 }
 #endif

--- a/intern/ghost/intern/GHOST_SparkleUpdater.h
+++ b/intern/ghost/intern/GHOST_SparkleUpdater.h
@@ -9,12 +9,5 @@ class SparkleUpdater {
   SparkleUpdater();
   ~SparkleUpdater();
 
-  bool getAutomaticDownload() const;
-  void setAutomaticDownload(bool value);
-
-  void checkAndShowUI();
-  void checkAndMaybeShowUI();
-  void checkWithoutUI();
-
   void checkForUpdates();
 };

--- a/intern/ghost/intern/GHOST_SparkleUpdater.mm
+++ b/intern/ghost/intern/GHOST_SparkleUpdater.mm
@@ -33,26 +33,6 @@ SparkleUpdater::~SparkleUpdater() {
   spuUpdater = nil;
 }
 
-bool SparkleUpdater::getAutomaticDownload() const {
-  return spuUpdater.automaticallyDownloadsUpdates;
-}
-
-void SparkleUpdater::setAutomaticDownload(bool value) {
-  spuUpdater.automaticallyDownloadsUpdates = value;
-}
-
-void SparkleUpdater::checkAndShowUI() {
-  [spuUpdater checkForUpdates];
-}
-
-void SparkleUpdater::checkAndMaybeShowUI() {
-  [spuUpdater checkForUpdatesInBackground];
-}
-
-void SparkleUpdater::checkWithoutUI() {
-  [spuUpdater checkForUpdateInformation];
-}
-
 void SparkleUpdater::checkForUpdates() {
   [spuUpdater checkForUpdates];
 }

--- a/source/blender/windowmanager/intern/wm_window.c
+++ b/source/blender/windowmanager/intern/wm_window.c
@@ -1603,7 +1603,7 @@ void wm_ghost_init(bContext *C)
 
     // ABLER: Updater for MacOS
 #if defined(__APPLE__)
-    GHOST_CreateAndCheckUpdater(g_system);
+    GHOST_CreateAndCheckSparkleUpdater(g_system);
 #endif
 
     if (C != NULL) {


### PR DESCRIPTION
## 관련 링크
[이슈](https://carpenstreet.atlassian.net/browse/SWTASK-251?atlOrigin=eyJpIjoiMzQ5NWUxMTFlOTQwNGMyMjg0ZDJlMjYxMjJlYmNjZTEiLCJwIjoiaiJ9)

## 발제/내용

- updater 라는 이름은 윈도우, 맥 두 경우 다 쓰이는 것처럼 느껴져서 명확한 이름으로 변경하는 것이 좋아 보임

## 대응

### 어떤 조치를 취했나요?

- updater 에서 sparkleUpdater 로 변수/함수 명을 변경하였습니다.
- SparkleUpdater 클래스에서 사용하지 않는 함수를 삭제했습니다.