### PR TITLE
기본값 프리셋 적용시 에러

### DIFF
--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -284,7 +284,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_x = 4800
         new_scene.render.resolution_y = 2700
 
-    if type == "Indoor Daytime":
+    elif type == "Indoor Daytime":
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -319,7 +319,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_x = 4800
         new_scene.render.resolution_y = 2700
 
-    if type == "Indoor Sunset":
+    elif type == "Indoor Sunset":
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -354,7 +354,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_x = 4800
         new_scene.render.resolution_y = 2700
 
-    if type == "Indoor Nighttime":
+    elif type == "Indoor Nighttime":
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -389,7 +389,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_x = 4800
         new_scene.render.resolution_y = 2700
 
-    if type == "Outdoor Daytime":
+    elif type == "Outdoor Daytime":
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -424,7 +424,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_x = 4800
         new_scene.render.resolution_y = 2700
 
-    if type == "Outdoor Sunset":
+    elif type == "Outdoor Sunset":
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -459,7 +459,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_x = 4800
         new_scene.render.resolution_y = 2700
 
-    if type == "Outdoor Nighttime":
+    elif type == "Outdoor Nighttime":
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -270,6 +270,8 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 1
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1
+        prop.exposure = 0.0
+        prop.gamma = 1.0
         prop.use_bloom = True
         prop.bloom_threshold = 1
         prop.bloom_knee = 0.5
@@ -303,6 +305,8 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 1.05
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1
+        prop.exposure = 0.0
+        prop.gamma = 1.0
         prop.use_bloom = True
         prop.bloom_threshold = 2
         prop.bloom_knee = 0.5
@@ -336,6 +340,8 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 0.9
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1
+        prop.exposure = 0.0
+        prop.gamma = 1.0
         prop.use_bloom = True
         prop.bloom_threshold = 1
         prop.bloom_knee = 0.5
@@ -369,6 +375,8 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 0.95
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1
+        prop.exposure = 0.0
+        prop.gamma = 1.0
         prop.use_bloom = True
         prop.bloom_threshold = 1
         prop.bloom_knee = 0.5
@@ -402,6 +410,8 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 1
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1
+        prop.exposure = 0.0
+        prop.gamma = 1.0
         prop.use_bloom = False
         prop.bloom_threshold = 1
         prop.bloom_knee = 0.5
@@ -435,6 +445,8 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 0.9
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1
+        prop.exposure = 0.0
+        prop.gamma = 1.0
         prop.use_bloom = True
         prop.bloom_threshold = 0.8
         prop.bloom_knee = 0.5
@@ -468,6 +480,8 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         prop.image_adjust_color_b = 1.1
         prop.image_adjust_hue = 0.5
         prop.image_adjust_saturation = 1.2
+        prop.exposure = 0.0
+        prop.gamma = 1.0
         new_scene.eevee.use_bloom = True
         new_scene.eevee.bloom_threshold = 1
         new_scene.eevee.bloom_knee = 0.5

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -203,6 +203,8 @@ def load_scene(self, context: Context) -> None:
     materials_handler.change_image_adjust_color(None, context)
     materials_handler.change_image_adjust_hue(None, context)
     materials_handler.change_image_adjust_saturation(None, context)
+    materials_handler.change_exposure(None, context)
+    materials_handler.change_gamma(None, context)
     bloom.change_bloom_threshold(None, context)
     bloom.change_bloom_knee(None, context)
     bloom.change_bloom_radius(None, context)


### PR DESCRIPTION
## 관련 링크
[링크](https://carpenstreet.atlassian.net/browse/SWTASK-263)

## 발제/내용

- 프리셋 씬에서 exposure, gamma 값에 대한 설정이 없음

## 대응

### 어떤 조치를 취했나요?

- 씬 설정 시 exposure, gamma 값에 default 설정(default 씬 이외에 다른 씬에도 추가해줘야 exposure, gamma 값 변경해도 영향을 받지 않음)
- load_scene에서 프로퍼티 update 함수를 추가