### PR TITLE
SWTASK-280 Shift+A 커맨드를 통한 조명추가 기능 제거

### DIFF
--- a/release/scripts/startup/bl_ui/space_view3d.py
+++ b/release/scripts/startup/bl_ui/space_view3d.py
@@ -2207,11 +2207,6 @@ class VIEW3D_MT_add(Menu):
 
         layout.separator()
 
-        layout.menu("VIEW3D_MT_light_add", icon='OUTLINER_OB_LIGHT')
-        layout.menu("VIEW3D_MT_lightprobe_add", icon='OUTLINER_OB_LIGHTPROBE')
-
-        layout.separator()
-
         if VIEW3D_MT_camera_add.is_extended():
             layout.menu("VIEW3D_MT_camera_add", icon='OUTLINER_OB_CAMERA')
         else:


### PR DESCRIPTION
DELETE - Shift+A 커맨드를 통해 가능했던 조명추가기능을 제거

오브젝트 모드 (기본모드)에서 Shift+A 를 누르면 Add menu가 팝업됨
이 상태에서 Light, Light Probe를 통해 dummy 조명 생성이 가능함
에이블러에서 컨트롤되지않는 조명을 없애기 위해, 이 기능을 UI에서 제거한다.

- 