### PR TITLE
SWTASK-279 새로운 맥북에서 빌드 / 배포되지 않는 문제

### DIFF
--- a/release/darwin/generate_appcast_and_image.sh
+++ b/release/darwin/generate_appcast_and_image.sh
@@ -46,7 +46,7 @@ cd "${_work_dir}"
 echo "Moving old versions..."
 
 mkdir -p ./old_versions
-find . -name "ABLER_MacOS_v*" -exec mv {} ./old_versions \;
+mv ./*.dmg ./old_versions
 mv ./*.xml ./old_versions
 
 # Generate appcast


### PR DESCRIPTION
## 관련 링크
[이슈](https://carpenstreet.atlassian.net/browse/SWTASK-279?atlOrigin=eyJpIjoiZThmMmY5ZmYxNWVjNDM5ZmI2ZjY1NTY2YmU2NDg5MzYiLCJwIjoiaiJ9)

## 발제/내용

- 기존에 특정 버전을 찾은 후 이동하던 로직을 모든 dmg 파일과 모든 xml 파일을 이동하는 로직으로 변경하였습니다.