### PR TITLE
SWTASK 287 조작 튜토리얼 내 가이드 보러가기 언어 오류

### DIFF
--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3260,7 +3260,15 @@ class WM_MT_splash_tutorial(Menu):
 
         row = layout.row()
         anchor = row.operator("wm.url_open", text="ABLER Guide", icon='URL')
-        anchor.url = 'https://acon3d.notion.site/ae6c0a608fd749b4a14b1cf98f058ff7'
+        cur_lang = bpy.context.preferences.view.language
+        if cur_lang == "ko_KR":
+            anchor.url = 'https://acon3d.notion.site/ae6c0a608fd749b4a14b1cf98f058ff7'
+        elif cur_lang == "ja_JP":
+            anchor.url = 'https://acon3d.notion.site/ABLER-bc26a6b09de14dfba8f9f10cebb87df2'
+        elif cur_lang == "zh_CN" or cur_lang == "zh_TW":
+            anchor.url = 'https://acon3d.notion.site/ABLER-1433d7c4cbb1496a883f9dee6b41fb68'
+        else: # en_US + 지원되지 않는 언어는 영어로
+            anchor.url = 'https://acon3d.notion.site/ABLER-User-Guide-316838433d0141ffa4dd11dccc80982c'  
         layout.separator()
 
         row = layout.row()

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3260,6 +3260,8 @@ class WM_MT_splash_tutorial(Menu):
 
         row = layout.row()
         anchor = row.operator("wm.url_open", text="ABLER Guide", icon='URL')
+        # general.py에 언어 설정 코드가 있긴 하지만 __init__.py가 달라 재활용할 수 없음
+        # 따라서 여기서 언어 설정 코드를 따로 지정
         cur_lang = bpy.context.preferences.view.language
         if cur_lang == "ko_KR":
             anchor.url = 'https://acon3d.notion.site/ae6c0a608fd749b4a14b1cf98f058ff7'


### PR DESCRIPTION
## 관련 링크
[링크](https://carpenstreet.atlassian.net/browse/SWTASK-287)

## 발제/내용

- 에이블러 언어 설정을 무시하고 무조건 한글 가이드 링크만 연결되어 있었음

## 대응

### 어떤 조치를 취했나요?

- 현재 에이블러 언어설정 값을 받아 해당 언어의 가이드 링크를 연결
- 영어 + 그 외의 언어는 영문 가이드로 연결