### PR TITLE
feature/SWTASK-214-macos-korean-search

### DIFF
--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -15,6 +15,8 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # ##### END GPL LICENSE BLOCK #####
+import urllib
+
 from ..lib.locales import supported_locales
 
 bl_info = {
@@ -865,7 +867,7 @@ class Acon3dGeneralPanel(bpy.types.Panel):
         row.scale_x = 30
         anchor = row.operator("acon3d.open_search_acon3d", text="Search")
         keyword = context.window_manager.ACON_prop.keyword_input
-        anchor.url = f"https://www.acon3d.com/{lang}/toon/search?keyword={keyword}&utm_source={utm_source}&utm_medium={utm_medium}&utm_campaign={utm_campaign}&utm_content={utm_content_for_search}&utm_term={keyword}"
+        anchor.url = f"https://www.acon3d.com/{lang}/toon/search?keyword={urllib.parse.quote(keyword)}&utm_source={utm_source}&utm_medium={utm_medium}&utm_campaign={utm_campaign}&utm_content={utm_content_for_search}&utm_term={keyword}"
 
         row = layout.row()
         row.scale_y = 1.0


### PR DESCRIPTION
[변경 내역]
- **ADD** urllib module import
- **CHANGE** anchor.url에 들어가는 keyword encoding

## 관련 링크
[Jira](https://carpenstreet.atlassian.net/browse/SWTASK-214)

## 발제/내용

- macOS에서만 한글로 검색을 입력했을 때 이상하게 깨진 링크로 연결됨

## 대응
### 어떤 조치를 취했나요?
- Windows에서는 인코딩이 기본 설정으로 잘 되는 것 같지만, macOS에서는 URL에서 많이 사용되는 Percent-Encoding이 제대로 적용이 안되는 것 같음. 그래서 강제로 적용을 시킴

### 잘 확인해보아야 할 것
- Windows에서 잘 적용이 되는지 확인해야함