### PR TITLE
[SWTASK-289] MacOS에서 Delete 대체 키 적용

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -4198,6 +4198,14 @@ def km_object_mode(params):
             ("object.data_transfer", {"type": 'T', "value": 'PRESS', "shift": True, "ctrl": True}, None),
         ])
 
+    if params.apple:
+        items.extend([
+            ("object.delete", {"type": 'BACK_SPACE', "value": 'PRESS'},
+             {"properties": [("use_global", False), ("confirm", False)]}),
+            ("object.delete", {"type": 'BACK_SPACE', "value": 'PRESS', "oskey": True},
+             {"properties": [("use_global", True), ("confirm", False)]}),
+        ])
+
     return keymap
 
 


### PR DESCRIPTION
# [Jira](https://carpenstreet.atlassian.net/browse/SWTASK-289)

전체 선택 (`A`로), delete를 하려고 할 때 backspace키로 안되고 `X` 누르고 안내에 따라 delete 마우스 클릭해야 지워짐.

별도 다른 delete 키가 필요할지?

## 작업 내용

MacOS에서는 기본적으로 Del 기능을 ⌘ + Backspace 로 실행할 수 있음.
그래서 에이블러에서 오브젝트 삭제에 사용하는 2개의 Del 동작을 Backspace로 변경함
`abler_default.py` 내부 `object.delete` 항목 중 `DEL` 을 사용하는 오브젝트 삭제 단축키는 다음과 같이 두개가 있음

- 기존의 단축키
  - `DEL`
  - `Shift` + `DEL`
- MacOS용 단축키
  - `if params.apple:` 구문 추가
  - `Backspace`
  - `⌘` + `DEL`

### 결과

위의 키로 오브젝트가 정상적으로 지워짐.
