### PR TITLE
SWTASK-86  실내조명 추가,제거,설정 기능

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -272,7 +272,7 @@ class AconSceneSelectedGroupProperty(bpy.types.PropertyGroup):
 
 
 @persistent
-def renew_aconlights(_dummy):
+def renew_acon_lights(_dummy):
     scene = bpy.context.scene
     cnt = len(scene.collection.objects)
 
@@ -300,11 +300,11 @@ class AconLight(bpy.types.PropertyGroup):
 
     @classmethod
     def register(cls):
-        bpy.app.handlers.depsgraph_update_post.append(renew_aconlights)
+        bpy.app.handlers.depsgraph_update_post.append(renew_acon_lights)
 
     @classmethod
     def unregister(cls):
-        bpy.app.handlers.depsgraph_update_post.remove(renew_aconlights)
+        bpy.app.handlers.depsgraph_update_post.remove(renew_acon_lights)
 
     # used to check if renew is needed
     scene_cache = None
@@ -755,7 +755,10 @@ class AconSceneProperty(bpy.types.PropertyGroup):
 
     lights: bpy.props.CollectionProperty(type=AconLight)
     light_index: bpy.props.IntProperty(
-        name="light index", default=0, update=scenes.change_ui_to_show_selected_light
+        name="",
+        min=0,
+        default=0,
+        update=scenes.change_ui_to_show_selected_light
     )
 
 

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -270,19 +270,22 @@ class AconSceneSelectedGroupProperty(bpy.types.PropertyGroup):
     )
 
 
-class AconLightWrapper(bpy.types.PropertyGroup):
+class AconLight(bpy.types.PropertyGroup):
     obj: bpy.props.PointerProperty(type=bpy.types.Object)
 
-class AconLightProperty(bpy.types.PropertyGroup):
-    @classmethod
-    def register(cls):
-        AconLightWrapper.ACON_prop = bpy.props.PointerProperty(
-            type=AconLightProperty
-        )
+    def change_light_data(self, context: bpy.types.Context) -> None:
+        index = context.scene.ACON_prop.light_index
+        data = context.scene.ACON_prop.lights[index].obj.data
+        prop = context.scene.ACON_prop.lights[index]
 
-    @classmethod
-    def unregister(cls):
-        del AconLightWrapper.Light.ACON_prop
+        data.color = prop.color
+        data.energy = prop.power
+        data.diffuse_factor = prop.diffuse_factor
+        data.specular_factor = prop.specular_factor
+        data.volume_factor = prop.volume_factor
+
+    def toggle_light(self, context: bpy.types.Context) -> None:
+        self.obj.hide_set(self.hide)
 
     color: bpy.props.FloatVectorProperty(
         name="Light Color",
@@ -291,7 +294,7 @@ class AconLightProperty(bpy.types.PropertyGroup):
         default=(1.0, 1.0, 1.0),
         min=0.0,
         max=100.0,
-        update=scenes.change_light_data
+        update=change_light_data
     )
 
     power: bpy.props.FloatProperty(
@@ -300,7 +303,7 @@ class AconLightProperty(bpy.types.PropertyGroup):
         default=10.0,
         min=0,
         max=1000.0,
-        update=scenes.change_light_data
+        update=change_light_data
     )
 
     diffuse_factor: bpy.props.FloatProperty(
@@ -309,7 +312,7 @@ class AconLightProperty(bpy.types.PropertyGroup):
         default=1.0,
         min=0,
         max=100.0,
-        update=scenes.change_light_data
+        update=change_light_data
     )
 
     specular_factor: bpy.props.FloatProperty(
@@ -318,7 +321,7 @@ class AconLightProperty(bpy.types.PropertyGroup):
         default=1.0,
         min=0,
         max=100.0,
-        update=scenes.change_light_data
+        update=change_light_data
     )
 
     volume_factor: bpy.props.FloatProperty(
@@ -327,7 +330,14 @@ class AconLightProperty(bpy.types.PropertyGroup):
         default=1.0,
         min=0,
         max=100.0,
-        update=scenes.change_light_data
+        update=change_light_data
+    )
+
+    hide: bpy.props.BoolProperty(
+        name="Hide Light",
+        description="True means hide off,and False means hide on",
+        default=False,
+        update=toggle_light
     )
 
 
@@ -708,7 +718,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         update=scenes.change_background_color,
     )
 
-    lights: bpy.props.CollectionProperty(type=AconLightWrapper)
+    lights: bpy.props.CollectionProperty(type=AconLight)
     light_index: bpy.props.IntProperty(
         name="light index",
         default=0,
@@ -856,8 +866,7 @@ classes = (
     AconWindowManagerProperty,
     CollectionLayerExcludeProperties,
     AconSceneSelectedGroupProperty,
-    AconLightWrapper,
-    AconLightProperty,
+    AconLight,
     AconSceneProperty,
     AconMaterialProperty,
     AconMeshProperty,

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -316,7 +316,7 @@ class AconLight(bpy.types.PropertyGroup):
         data = aconlight.obj.data
 
         data.color = aconlight.color
-        data.energy = aconlight.power
+        data.energy = aconlight.energy
         data.diffuse_factor = aconlight.diffuse_factor
         data.specular_factor = aconlight.specular_factor
         data.volume_factor = aconlight.volume_factor
@@ -325,7 +325,7 @@ class AconLight(bpy.types.PropertyGroup):
         self.obj.hide_set(self.is_hidden)
 
     color: bpy.props.FloatVectorProperty(
-        name="Light Color",
+        name="",
         description="Adjust light color",
         subtype="COLOR",
         default=(1.0, 1.0, 1.0),
@@ -334,9 +334,9 @@ class AconLight(bpy.types.PropertyGroup):
         update=change_light_data,
     )
 
-    power: bpy.props.FloatProperty(
-        name="Light Power",
-        description="Adjust light power",
+    energy: bpy.props.FloatProperty(
+        name="",
+        description="Adjust light energy",
         default=10.0,
         min=0,
         max=1000.0,
@@ -344,7 +344,7 @@ class AconLight(bpy.types.PropertyGroup):
     )
 
     diffuse_factor: bpy.props.FloatProperty(
-        name="Light Diffuse",
+        name="",
         description="Adjust light diffuse",
         default=1.0,
         min=0,
@@ -353,7 +353,7 @@ class AconLight(bpy.types.PropertyGroup):
     )
 
     specular_factor: bpy.props.FloatProperty(
-        name="Light Specular",
+        name="",
         description="Adjust light specular",
         default=1.0,
         min=0,
@@ -362,7 +362,7 @@ class AconLight(bpy.types.PropertyGroup):
     )
 
     volume_factor: bpy.props.FloatProperty(
-        name="Light Volume",
+        name="",
         description="Adjust light volume",
         default=1.0,
         min=0,
@@ -371,8 +371,8 @@ class AconLight(bpy.types.PropertyGroup):
     )
 
     is_hidden: bpy.props.BoolProperty(
-        name="Hide Light",
-        description="True means hide off,and False means hide on",
+        name="",
+        description="Toggle selected light",
         default=False,
         update=toggle_light,
     )
@@ -514,9 +514,8 @@ class AconSceneProperty(bpy.types.PropertyGroup):
     )
 
     toggle_lights: bpy.props.BoolProperty(
-        # name="Lights",
         name="",
-        description="Express additional lights",
+        description="Lights",
         default=True,
     )
 

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -294,8 +294,10 @@ def renew_aconlights(_dummy):
         lights.remove(index - counter)
         cnt = cnt + 1
 
+
 class AconLight(bpy.types.PropertyGroup):
     obj: bpy.props.PointerProperty(type=bpy.types.Object)
+
     @classmethod
     def register(cls):
         bpy.app.handlers.depsgraph_update_post.append(renew_aconlights)
@@ -308,17 +310,16 @@ class AconLight(bpy.types.PropertyGroup):
     scene_cache = None
     obj_cnt_cache = 0
 
-
     def change_light_data(self, context: bpy.types.Context) -> None:
-        index = context.scene.ACON_prop.light_index
-        data = context.scene.ACON_prop.lights[index].obj.data
-        prop = context.scene.ACON_prop.lights[index]
+        prop = context.scene.ACON_prop
+        aconlight = prop.lights[prop.light_index]
+        data = aconlight.obj.data
 
-        data.color = prop.color
-        data.energy = prop.power
-        data.diffuse_factor = prop.diffuse_factor
-        data.specular_factor = prop.specular_factor
-        data.volume_factor = prop.volume_factor
+        data.color = aconlight.color
+        data.energy = aconlight.power
+        data.diffuse_factor = aconlight.diffuse_factor
+        data.specular_factor = aconlight.specular_factor
+        data.volume_factor = aconlight.volume_factor
 
     def toggle_light(self, context: bpy.types.Context) -> None:
         self.obj.hide_set(self.hide)
@@ -369,7 +370,7 @@ class AconLight(bpy.types.PropertyGroup):
         update=change_light_data
     )
 
-    hide: bpy.props.BoolProperty(
+    is_hidden: bpy.props.BoolProperty(
         name="Hide Light",
         description="True means hide off,and False means hide on",
         default=False,

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -42,6 +42,64 @@ class AconSceneColGroupProperty(bpy.types.PropertyGroup):
     )
 
 
+class AconLightProperty(bpy.types.PropertyGroup):
+    @classmethod
+    def register(cls):
+        bpy.types.Light.ACON_prop = bpy.props.PointerProperty(
+            type=AconLightProperty
+        )
+
+    @classmethod
+    def unregister(cls):
+        del bpy.types.Light.ACON_prop
+
+    color: bpy.props.FloatVectorProperty(
+        name="Light Color",
+        description="Change light color",
+        subtype="COLOR",
+        default=(1.0, 1.0, 1.0),
+        min=0.0,
+        max=100.0,
+        update=scenes.change_light_data
+    )
+
+    power: bpy.props.FloatProperty(
+        name="Light Power",
+        description="Adjust maximum intensity of bloom effect that each pixel can have (0 to disable) (Range: 0 ~ 1000)",
+        default=10.0,
+        min=-1000.0,
+        max=1000.0,
+        update=scenes.change_light_data
+    )
+
+    diffuse_factor: bpy.props.FloatProperty(
+        name="Light Diffuse",
+        description="Adjust maximum intensity of bloom effect that each pixel can have (0 to disable) (Range: 0 ~ 1000)",
+        default=1.0,
+        min=0,
+        max=100.0,
+        update=scenes.change_light_data
+    )
+
+    specular_factor: bpy.props.FloatProperty(
+        name="Light Specular",
+        description="Adjust maximum intensity of bloom effect that each pixel can have (0 to disable) (Range: 0 ~ 1000)",
+        default=1.0,
+        min=0,
+        max=100.0,
+        update=scenes.change_light_data
+    )
+
+    volume_factor: bpy.props.FloatProperty(
+        name="Light Volume",
+        description="Adjust maximum intensity of bloom effect that each pixel can have (0 to disable) (Range: 0 ~ 1000)",
+        default=0,
+        min=0,
+        max=100.0,
+        update=scenes.change_light_data
+    )
+
+
 class AconWindowManagerProperty(bpy.types.PropertyGroup):
     @classmethod
     def register(cls):
@@ -269,6 +327,9 @@ class AconSceneSelectedGroupProperty(bpy.types.PropertyGroup):
         ],
     )
 
+
+class AconLightWrapper(bpy.types.PropertyGroup):
+    obj: bpy.props.PointerProperty(type=bpy.types.Object)
 
 class AconSceneProperty(bpy.types.PropertyGroup):
     @classmethod
@@ -647,6 +708,13 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         update=scenes.change_background_color,
     )
 
+    lights: bpy.props.CollectionProperty(type=AconLightWrapper)
+    light_index: bpy.props.IntProperty(
+        name="light index",
+        default=0,
+        update=scenes.change_ui_to_show_selected_light
+    )
+
 
 class AconMaterialProperty(bpy.types.PropertyGroup):
     @classmethod
@@ -788,6 +856,8 @@ classes = (
     AconWindowManagerProperty,
     CollectionLayerExcludeProperties,
     AconSceneSelectedGroupProperty,
+    AconLightProperty,
+    AconLightWrapper,
     AconSceneProperty,
     AconMaterialProperty,
     AconMeshProperty,

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -270,6 +270,7 @@ class AconSceneSelectedGroupProperty(bpy.types.PropertyGroup):
         ],
     )
 
+
 @persistent
 def renew_aconlights(_dummy):
     scene = bpy.context.scene
@@ -516,7 +517,6 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         name="",
         description="Express additional lights",
         default=True,
-        update=materials_handler.toggle_lights,
     )
 
     toggle_shadow_shading: bpy.props.BoolProperty(

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -274,13 +274,13 @@ class AconSceneSelectedGroupProperty(bpy.types.PropertyGroup):
 @persistent
 def renew_acon_lights(_dummy):
     scene = bpy.context.scene
-    cnt = len(scene.collection.objects)
+    obj_cnt = len(scene.collection.objects)
 
-    if scene == AconLight.scene_cache and cnt == AconLight.obj_cnt_cache:
+    if scene == AconLight.scene_cache and obj_cnt == AconLight.obj_cnt_cache:
         return
 
     AconLight.scene_cache = scene
-    AconLight.obj_cnt_cache = cnt
+    AconLight.obj_cnt_cache = obj_cnt
 
     delete_indices = []
     lights = scene.ACON_prop.lights
@@ -292,7 +292,7 @@ def renew_acon_lights(_dummy):
     counter = 0
     for index in delete_indices:
         lights.remove(index - counter)
-        cnt = cnt + 1
+        counter = counter + 1
 
 
 class AconLight(bpy.types.PropertyGroup):

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -322,7 +322,7 @@ class AconLight(bpy.types.PropertyGroup):
         data.volume_factor = aconlight.volume_factor
 
     def toggle_light(self, context: bpy.types.Context) -> None:
-        self.obj.hide_set(self.hide)
+        self.obj.hide_set(self.is_hidden)
 
     color: bpy.props.FloatVectorProperty(
         name="Light Color",
@@ -331,7 +331,7 @@ class AconLight(bpy.types.PropertyGroup):
         default=(1.0, 1.0, 1.0),
         min=0.0,
         max=100.0,
-        update=change_light_data
+        update=change_light_data,
     )
 
     power: bpy.props.FloatProperty(
@@ -340,7 +340,7 @@ class AconLight(bpy.types.PropertyGroup):
         default=10.0,
         min=0,
         max=1000.0,
-        update=change_light_data
+        update=change_light_data,
     )
 
     diffuse_factor: bpy.props.FloatProperty(
@@ -349,7 +349,7 @@ class AconLight(bpy.types.PropertyGroup):
         default=1.0,
         min=0,
         max=100.0,
-        update=change_light_data
+        update=change_light_data,
     )
 
     specular_factor: bpy.props.FloatProperty(
@@ -358,7 +358,7 @@ class AconLight(bpy.types.PropertyGroup):
         default=1.0,
         min=0,
         max=100.0,
-        update=change_light_data
+        update=change_light_data,
     )
 
     volume_factor: bpy.props.FloatProperty(
@@ -367,14 +367,14 @@ class AconLight(bpy.types.PropertyGroup):
         default=1.0,
         min=0,
         max=100.0,
-        update=change_light_data
+        update=change_light_data,
     )
 
     is_hidden: bpy.props.BoolProperty(
         name="Hide Light",
         description="True means hide off,and False means hide on",
         default=False,
-        update=toggle_light
+        update=toggle_light,
     )
 
 
@@ -756,9 +756,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
 
     lights: bpy.props.CollectionProperty(type=AconLight)
     light_index: bpy.props.IntProperty(
-        name="light index",
-        default=0,
-        update=scenes.change_ui_to_show_selected_light
+        name="light index", default=0, update=scenes.change_ui_to_show_selected_light
     )
 
 

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -42,64 +42,6 @@ class AconSceneColGroupProperty(bpy.types.PropertyGroup):
     )
 
 
-class AconLightProperty(bpy.types.PropertyGroup):
-    @classmethod
-    def register(cls):
-        bpy.types.Light.ACON_prop = bpy.props.PointerProperty(
-            type=AconLightProperty
-        )
-
-    @classmethod
-    def unregister(cls):
-        del bpy.types.Light.ACON_prop
-
-    color: bpy.props.FloatVectorProperty(
-        name="Light Color",
-        description="Change light color",
-        subtype="COLOR",
-        default=(1.0, 1.0, 1.0),
-        min=0.0,
-        max=100.0,
-        update=scenes.change_light_data
-    )
-
-    power: bpy.props.FloatProperty(
-        name="Light Power",
-        description="Adjust maximum intensity of bloom effect that each pixel can have (0 to disable) (Range: 0 ~ 1000)",
-        default=10.0,
-        min=-1000.0,
-        max=1000.0,
-        update=scenes.change_light_data
-    )
-
-    diffuse_factor: bpy.props.FloatProperty(
-        name="Light Diffuse",
-        description="Adjust maximum intensity of bloom effect that each pixel can have (0 to disable) (Range: 0 ~ 1000)",
-        default=1.0,
-        min=0,
-        max=100.0,
-        update=scenes.change_light_data
-    )
-
-    specular_factor: bpy.props.FloatProperty(
-        name="Light Specular",
-        description="Adjust maximum intensity of bloom effect that each pixel can have (0 to disable) (Range: 0 ~ 1000)",
-        default=1.0,
-        min=0,
-        max=100.0,
-        update=scenes.change_light_data
-    )
-
-    volume_factor: bpy.props.FloatProperty(
-        name="Light Volume",
-        description="Adjust maximum intensity of bloom effect that each pixel can have (0 to disable) (Range: 0 ~ 1000)",
-        default=0,
-        min=0,
-        max=100.0,
-        update=scenes.change_light_data
-    )
-
-
 class AconWindowManagerProperty(bpy.types.PropertyGroup):
     @classmethod
     def register(cls):
@@ -330,6 +272,64 @@ class AconSceneSelectedGroupProperty(bpy.types.PropertyGroup):
 
 class AconLightWrapper(bpy.types.PropertyGroup):
     obj: bpy.props.PointerProperty(type=bpy.types.Object)
+
+class AconLightProperty(bpy.types.PropertyGroup):
+    @classmethod
+    def register(cls):
+        AconLightWrapper.ACON_prop = bpy.props.PointerProperty(
+            type=AconLightProperty
+        )
+
+    @classmethod
+    def unregister(cls):
+        del AconLightWrapper.Light.ACON_prop
+
+    color: bpy.props.FloatVectorProperty(
+        name="Light Color",
+        description="Adjust light color",
+        subtype="COLOR",
+        default=(1.0, 1.0, 1.0),
+        min=0.0,
+        max=100.0,
+        update=scenes.change_light_data
+    )
+
+    power: bpy.props.FloatProperty(
+        name="Light Power",
+        description="Adjust light power",
+        default=10.0,
+        min=0,
+        max=1000.0,
+        update=scenes.change_light_data
+    )
+
+    diffuse_factor: bpy.props.FloatProperty(
+        name="Light Diffuse",
+        description="Adjust light diffuse",
+        default=1.0,
+        min=0,
+        max=100.0,
+        update=scenes.change_light_data
+    )
+
+    specular_factor: bpy.props.FloatProperty(
+        name="Light Specular",
+        description="Adjust light specular",
+        default=1.0,
+        min=0,
+        max=100.0,
+        update=scenes.change_light_data
+    )
+
+    volume_factor: bpy.props.FloatProperty(
+        name="Light Volume",
+        description="Adjust light volume",
+        default=1.0,
+        min=0,
+        max=100.0,
+        update=scenes.change_light_data
+    )
+
 
 class AconSceneProperty(bpy.types.PropertyGroup):
     @classmethod
@@ -856,8 +856,8 @@ classes = (
     AconWindowManagerProperty,
     CollectionLayerExcludeProperties,
     AconSceneSelectedGroupProperty,
-    AconLightProperty,
     AconLightWrapper,
+    AconLightProperty,
     AconSceneProperty,
     AconMaterialProperty,
     AconMeshProperty,

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -405,6 +405,14 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         update=shadow.change_sun_strength,
     )
 
+    toggle_lights: bpy.props.BoolProperty(
+        # name="Lights",
+        name="",
+        description="Express additional lights",
+        default=True,
+        update=materials_handler.toggle_lights,
+    )
+
     toggle_shadow_shading: bpy.props.BoolProperty(
         name="",
         description="Express shadow and shading",

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -252,7 +252,7 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator, AconExportHelper):
         if "." in self.basename:
             self.basename = ".".join(self.basename.split(".")[:-1])
 
-        bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay.show_extras=False
+        context.screen.areas[0].spaces[0].overlay.show_extras = False
         res = super().execute(context)
         return res
 
@@ -280,7 +280,7 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator, AconExportHelper):
                 context.preferences.view.render_display_type = self.initial_display_type
 
                 self.report({"INFO"}, "RENDER QUEUE FINISHED")
-                bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay.show_extras=True
+                context.screen.areas[0].spaces[0].overlay.show_extras = True
 
                 bpy.ops.acon3d.alert(
                     "INVOKE_DEFAULT",

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -252,7 +252,9 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator, AconExportHelper):
         if "." in self.basename:
             self.basename = ".".join(self.basename.split(".")[:-1])
 
-        return super().execute(context)
+        bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay.show_extras=False
+        res = super().execute(context)
+        return res
 
     def prepare_queue(self, context):
         # File name duplicate check
@@ -278,6 +280,7 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator, AconExportHelper):
                 context.preferences.view.render_display_type = self.initial_display_type
 
                 self.report({"INFO"}, "RENDER QUEUE FINISHED")
+                bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay.show_extras=True
 
                 bpy.ops.acon3d.alert(
                     "INVOKE_DEFAULT",

--- a/release/scripts/startup/abler/lib/materials/materials_handler.py
+++ b/release/scripts/startup/abler/lib/materials/materials_handler.py
@@ -122,14 +122,6 @@ def toggle_texture(self, context: Context) -> None:
         return
     node.inputs[0].default_value = textureFactorValue
 
-def toggle_lights(self, context: Context) -> None:
-    if not context:
-        context = bpy.context
-
-    if not self:
-        self = context.scene.ACON_prop
-
-
 def toggle_shading(self, context: Context) -> None:
     if not context:
         context = bpy.context

--- a/release/scripts/startup/abler/lib/materials/materials_handler.py
+++ b/release/scripts/startup/abler/lib/materials/materials_handler.py
@@ -122,6 +122,13 @@ def toggle_texture(self, context: Context) -> None:
         return
     node.inputs[0].default_value = textureFactorValue
 
+def toggle_lights(self, context: Context) -> None:
+    if not context:
+        context = bpy.context
+
+    if not self:
+        self = context.scene.ACON_prop
+
 
 def toggle_shading(self, context: Context) -> None:
     if not context:

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -97,14 +97,19 @@ def change_background_color(self, context: Context) -> None:
     ui.transparent_checker_primary = background_color
     ui.transparent_checker_secondary = background_color
 
+
 def change_ui_to_show_selected_light(self, context: Context) -> None:
     index = context.scene.ACON_prop.light_index
 
     if not context.scene.ACON_prop.lights:
         return
 
-    data = context.scene.ACON_prop.lights[index].obj.data
     light = context.scene.ACON_prop.lights[index]
+
+    if light.obj:
+        data = light.obj.data
+    else:
+        return
     light.color = data.color
     light.power = data.energy
     light.diffuse_factor = data.diffuse_factor
@@ -114,6 +119,7 @@ def change_ui_to_show_selected_light(self, context: Context) -> None:
     # select current light item
     bpy.ops.object.select_all(action='DESELECT')
     context.scene.ACON_prop.lights[index].obj.select_set(True)
+
 
 # scene_items should be a global variable due to a bug in EnumProperty
 scene_items: List[Tuple[str, str, str]] = []
@@ -269,9 +275,8 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
     # Light는 Object이긴 하지만, Scene별로 관리되도록 하기 위해 복사하지 않는다.
     for acon_light in prop.lights:
         new_scene.collection.objects.unlink(acon_light.obj)
-        
-    prop.lights.clear()
 
+    prop.lights.clear()
 
     if type == "Default":
         prop.toggle_toon_edge = True

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -97,18 +97,6 @@ def change_background_color(self, context: Context) -> None:
     ui.transparent_checker_primary = background_color
     ui.transparent_checker_secondary = background_color
 
-
-def change_light_data(self, context: Context) -> None:
-    index = context.scene.ACON_prop.light_index
-    data = context.scene.ACON_prop.lights[index].obj.data
-    prop = context.scene.ACON_prop.lights[index].ACON_prop
-
-    data.color = prop.color
-    data.energy = prop.power
-    data.diffuse_factor = prop.diffuse_factor
-    data.specular_factor = prop.specular_factor
-    data.volume_factor = prop.volume_factor
-
 def change_ui_to_show_selected_light(self, context: Context) -> None:
     print("change_prop_to_show...")
     if not context.scene.ACON_prop.lights:
@@ -118,12 +106,12 @@ def change_ui_to_show_selected_light(self, context: Context) -> None:
     index = context.scene.ACON_prop.light_index
     data = context.scene.ACON_prop.lights[index].obj.data
 
-    prop = context.scene.ACON_prop.lights[index].ACON_prop
-    prop.color = data.color
-    prop.power = data.energy
-    prop.diffuse_factor = data.diffuse_factor
-    prop.volume_factor = data.volume_factor
-    prop.specular_factor = data.specular_factor
+    light = context.scene.ACON_prop.lights[index]
+    light.color = data.color
+    light.power = data.energy
+    light.diffuse_factor = data.diffuse_factor
+    light.volume_factor = data.volume_factor
+    light.specular_factor = data.specular_factor
 
     # select current light item
     bpy.ops.object.select_all(action='DESELECT')

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -98,12 +98,12 @@ def change_background_color(self, context: Context) -> None:
     ui.transparent_checker_secondary = background_color
 
 def change_ui_to_show_selected_light(self, context: Context) -> None:
+    index = context.scene.ACON_prop.light_index
+
     if not context.scene.ACON_prop.lights:
         return
 
-    index = context.scene.ACON_prop.light_index
     data = context.scene.ACON_prop.lights[index].obj.data
-
     light = context.scene.ACON_prop.lights[index]
     light.color = data.color
     light.power = data.energy

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -98,6 +98,40 @@ def change_background_color(self, context: Context) -> None:
     ui.transparent_checker_secondary = background_color
 
 
+def change_light_data(self, context: Context) -> None:
+    index = context.scene.ACON_prop.light_index
+    data = context.scene.ACON_prop.lights[index].obj.data
+    prop = bpy.data.lights[0].ACON_prop
+
+    data.color = prop.color
+    data.energy = prop.power
+    data.diffuse_factor = prop.diffuse_factor
+    data.specular_factor = prop.specular_factor
+    data.volume_factor = prop.volume_factor
+
+def change_ui_to_show_selected_light(self, context: Context) -> None:
+    print("change_prop_to_show...")
+    if not context.scene.ACON_prop.lights:
+        print("no lights, return")
+        return
+
+    index = context.scene.ACON_prop.light_index
+    data = context.scene.ACON_prop.lights[index].obj.data
+
+    print(index)
+
+    prop = bpy.data.lights[0].ACON_prop
+    prop.color = data.color
+    prop.power = data.energy
+    prop.diffuse_factor = data.diffuse_factor
+    prop.volume_factor = data.volume_factor
+    prop.specular_factor = data.specular_factor
+
+    # select current light item
+    bpy.ops.object.select_all(action='DESELECT')
+    context.scene.ACON_prop.lights[index].obj.select_set(True)
+
+
 # scene_items should be a global variable due to a bug in EnumProperty
 scene_items: List[Tuple[str, str, str]] = []
 

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -98,9 +98,7 @@ def change_background_color(self, context: Context) -> None:
     ui.transparent_checker_secondary = background_color
 
 def change_ui_to_show_selected_light(self, context: Context) -> None:
-    print("change_prop_to_show...")
     if not context.scene.ACON_prop.lights:
-        print("no lights, return")
         return
 
     index = context.scene.ACON_prop.light_index
@@ -116,7 +114,6 @@ def change_ui_to_show_selected_light(self, context: Context) -> None:
     # select current light item
     bpy.ops.object.select_all(action='DESELECT')
     context.scene.ACON_prop.lights[index].obj.select_set(True)
-
 
 # scene_items should be a global variable due to a bug in EnumProperty
 scene_items: List[Tuple[str, str, str]] = []
@@ -268,6 +265,13 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         cameras.turn_on_camera_view(False)
 
     prop = new_scene.ACON_prop
+
+    # Light는 Object이긴 하지만, Scene별로 관리되도록 하기 위해 복사하지 않는다.
+    for acon_light in prop.lights:
+        new_scene.collection.objects.unlink(acon_light.obj)
+        
+    prop.lights.clear()
+
 
     if type == "Default":
         prop.toggle_toon_edge = True

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -101,7 +101,7 @@ def change_background_color(self, context: Context) -> None:
 def change_light_data(self, context: Context) -> None:
     index = context.scene.ACON_prop.light_index
     data = context.scene.ACON_prop.lights[index].obj.data
-    prop = bpy.data.lights[0].ACON_prop
+    prop = context.scene.ACON_prop.lights[index].ACON_prop
 
     data.color = prop.color
     data.energy = prop.power
@@ -118,9 +118,7 @@ def change_ui_to_show_selected_light(self, context: Context) -> None:
     index = context.scene.ACON_prop.light_index
     data = context.scene.ACON_prop.lights[index].obj.data
 
-    print(index)
-
-    prop = bpy.data.lights[0].ACON_prop
+    prop = context.scene.ACON_prop.lights[index].ACON_prop
     prop.color = data.color
     prop.power = data.energy
     prop.diffuse_factor = data.diffuse_factor

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -97,8 +97,12 @@ def change_background_color(self, context: Context) -> None:
     ui.transparent_checker_primary = background_color
     ui.transparent_checker_secondary = background_color
 
-
 def change_ui_to_show_selected_light(self, context: Context) -> None:
+    """
+    ACON_prop의 light_index가 변경되었을때 아래의 로직을 수행한다
+    1. 실제 조명의 data와 ui로 보여지는 properties를 동기화
+    2. 뷰포트 상에서 해당 조명을 조작할 수 있도록 선택 처리
+    """
     index = context.scene.ACON_prop.light_index
 
     if not context.scene.ACON_prop.lights:

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -97,6 +97,7 @@ def change_background_color(self, context: Context) -> None:
     ui.transparent_checker_primary = background_color
     ui.transparent_checker_secondary = background_color
 
+
 def change_ui_to_show_selected_light(self, context: Context) -> None:
     """
     ACON_prop의 light_index가 변경되었을때 아래의 로직을 수행한다
@@ -115,13 +116,13 @@ def change_ui_to_show_selected_light(self, context: Context) -> None:
     else:
         return
     light.color = data.color
-    light.power = data.energy
+    light.energy = data.energy
     light.diffuse_factor = data.diffuse_factor
     light.volume_factor = data.volume_factor
     light.specular_factor = data.specular_factor
 
     # select current light item
-    bpy.ops.object.select_all(action='DESELECT')
+    bpy.ops.object.select_all(action="DESELECT")
     context.scene.ACON_prop.lights[index].obj.select_set(True)
 
 

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -35,6 +35,7 @@ def init_setting(dummy):
             init_screen.show_gizmo_tool = True
             init_screen.show_gizmo_context = True
             init_screen.overlay.show_ortho_grid = False
+            init_screen.overlay.show_extras = True
 
         except:
             print("Failed to find screen 'ACON3D'")

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -133,7 +133,7 @@ class LIGHT_UL_List(bpy.types.UIList):
         self.use_filter_sort_reverse = True
 
     def draw_item(
-            self, context, layout, data, item, icon, active_data, active_propname
+        self, context, layout, data, item, icon, active_data, active_propname
     ):
         if self.layout_type in {"DEFAULT", "COMPACT"}:
             if not item.obj.data:
@@ -142,12 +142,17 @@ class LIGHT_UL_List(bpy.types.UIList):
             row = layout.row(align=True)
             obj = item.obj
             if light_type == "POINT":
-                row.label(icon='LIGHT_POINT', text=obj.name)
+                row.label(icon="LIGHT_POINT", text=obj.name)
             elif light_type == "SPOT":
-                row.label(icon='LIGHT_SPOT', text=obj.name)
+                row.label(icon="LIGHT_SPOT", text=obj.name)
             elif light_type == "AREA":
-                row.label(icon='LIGHT_AREA', text=obj.name)
-            row.prop(item, "is_hidden", text="", icon='HIDE_ON' if item.is_hidden else "HIDE_OFF")
+                row.label(icon="LIGHT_AREA", text=obj.name)
+            row.prop(
+                item,
+                "is_hidden",
+                text="",
+                icon="HIDE_ON" if item.is_hidden else "HIDE_OFF",
+            )
 
 
 class LightPanel(bpy.types.Panel):
@@ -175,7 +180,9 @@ class LightPanel(bpy.types.Panel):
             # PointLight 생성버튼
             row = layout.row(align=True)
             col = row.column()
-            col.operator(AddPointLightOperator.bl_idname, text="Point", icon="LIGHT_POINT")
+            col.operator(
+                AddPointLightOperator.bl_idname, text="Point", icon="LIGHT_POINT"
+            )
 
             # SpotLight 생성버튼
             col = row.column()
@@ -193,7 +200,7 @@ class LightPanel(bpy.types.Panel):
                 scene_prop,
                 "lights",
                 scene_prop,
-                "light_index"
+                "light_index",
             )
             col = row.column()
             col.operator(RemoveLightOperator.bl_idname, text="", icon="REMOVE")
@@ -235,7 +242,9 @@ class AddLightOperatorBase(bpy.types.Operator):
         name = "ACON_light"
 
         # while 여러번 돌 수 있으므로. reference로 리스트를 먼저 한번 생성해준다.
-        light_names = [obj.name for obj in self.scene.collection.objects if obj.type == 'LIGHT']
+        light_names = [
+            obj.name for obj in self.scene.collection.objects if obj.type == "LIGHT"
+        ]
 
         while name in light_names:
             prefix = name.rsplit(".")[0]
@@ -254,7 +263,7 @@ class AddLightOperatorBase(bpy.types.Operator):
 
         # object 생성
         acon_light: Object = bpy.data.objects.new(light_name, acon_light_data)
-        return (acon_light)
+        return acon_light
 
     def execute(self, context):
         light_name = self.__generate_light_name()
@@ -375,7 +384,9 @@ class ShadingPanel(bpy.types.Panel):
 
 
 class MATERIAL_UL_List(bpy.types.UIList):
-    def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
+    def draw_item(
+        self, context, layout, data, item, icon, active_data, active_propname
+    ):
         layout.use_property_split = True
         layout.use_property_decorate = False
         ob = data

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -238,37 +238,16 @@ class AddLightOperatorBase(bpy.types.Operator):
         self.scene = bpy.context.scene
         return self.execute(context)
 
-    def _generate_light_name(self) -> str:
-        # set default name
-        name = "ACON_light"
-
-        # while 여러번 돌 수 있으므로. reference로 리스트를 먼저 한번 생성해준다.
-        light_names = [
-            obj.name for obj in self.scene.collection.objects if obj.type == "LIGHT"
-        ]
-
-        while name in light_names:
-            prefix = name.rsplit(".")[0]
-            postfix = name.rsplit(".")[-1]
-            if postfix.isnumeric():
-                postfix = str(int(postfix) + 1).zfill(3)
-            else:
-                postfix = "001"
-            name = prefix + "." + postfix
-
-        return name
-
-    def _create_light_on_scene(self, light_name: str):
-        acon_light_data: Light = bpy.data.lights.new(light_name, type=self.light_type)
+    def _create_light_on_scene(self):
+        acon_light_data: Light = bpy.data.lights.new(name="ACON_light", type=self.light_type)
         acon_light_data.energy = 10
 
         # object 생성
-        acon_light: Object = bpy.data.objects.new(light_name, acon_light_data)
+        acon_light: Object = bpy.data.objects.new(acon_light_data.name, acon_light_data)
         return acon_light
 
     def execute(self, context):
-        light_name = self._generate_light_name()
-        light = self._create_light_on_scene(light_name)
+        light = self._create_light_on_scene()
         self.scene.collection.objects.link(light)
         item = self.scene.ACON_prop.lights.add()
         item.obj = light
@@ -304,7 +283,7 @@ class RemoveLightOperator(bpy.types.Operator):
         index = scene.ACON_prop.light_index
         lights = scene.ACON_prop.lights
 
-        if not index in range(0, len(lights)):
+        if index >= len(lights):
             return {"FINISHED"}
 
         light_obj = scene.ACON_prop.lights[index].obj
@@ -314,6 +293,9 @@ class RemoveLightOperator(bpy.types.Operator):
 
         # ACON_prop.lights 데이터 제거
         scene.ACON_prop.lights.remove(index)
+
+        if index > 0:
+            index = index - 1
 
         return {"FINISHED"}
 

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -140,11 +140,12 @@ class LIGHT_UL_List(bpy.types.UIList):
             light_type = item.obj.data.type
             obj = item.obj
             if light_type == 'POINT':
-                row.prop(obj, "name", icon='LIGHT_POINT', emboss=False)
+                row.label(icon='LIGHT_POINT', text=obj.name)
             elif light_type == 'SPOT':
-                row.prop(obj, "name", icon='LIGHT_SPOT', emboss=False)
+                row.label(icon='LIGHT_SPOT', text=obj.name)
             elif light_type == 'AREA':
-                row.prop(obj, "name", icon='LIGHT_AREA', emboss=False)
+                row.label(icon='LIGHT_AREA', text=obj.name)
+            row.prop(item, "hide", text="", icon='HIDE_ON' if item.hide else 'HIDE_OFF')
 
 class LightPanel(bpy.types.Panel):
     bl_parent_id = "ACON_PT_Styles"
@@ -202,17 +203,17 @@ class LightPanel(bpy.types.Panel):
 
             if scene_prop.lights:
                 index = scene_prop.light_index
-                light_prop = scene_prop.lights[index].ACON_prop
+                light = scene_prop.lights[index]
                 row = layout.row(align=True)
-                row.prop(light_prop, "color", text="Color", slider=False)
+                row.prop(light, "color", text="Color", slider=True)
                 row = layout.row(align=True)
-                row.prop(light_prop, "power", text="Power", slider=True)
+                row.prop(light, "power", text="Power", slider=True)
                 row = layout.row(align=True)
-                row.prop(light_prop, "diffuse_factor", text="Diffuse", slider=True)
+                row.prop(light, "diffuse_factor", text="Diffuse", slider=True)
                 row = layout.row(align=True)
-                row.prop(light_prop, "specular_factor", text="Specular", slider=True)
+                row.prop(light, "specular_factor", text="Specular", slider=True)
                 row = layout.row(align=True)
-                row.prop(light_prop, "volume_factor", text="Volume", slider=True)
+                row.prop(light, "volume_factor", text="Volume", slider=True)
 
 
 
@@ -288,8 +289,6 @@ class RemoveLightOperator(bpy.types.Operator):
     bl_options = {"REGISTER"}
     bl_translation_context = "abler"
 
-    scene: bpy.types.Scene
-
     def execute(self, context):
         scene = context.scene
         index = scene.ACON_prop.light_index
@@ -307,7 +306,6 @@ class RemoveLightOperator(bpy.types.Operator):
         scene.ACON_prop.lights.remove(index)
 
         return {"FINISHED"}
-
 
 class ShadowShadingPanel(bpy.types.Panel):
     bl_parent_id = "ACON_PT_Styles"

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -177,8 +177,9 @@ class LightPanel(bpy.types.Panel):
             # Add Light
             row.label(text="Add Light")
 
-            # PointLight 생성버튼
             row = layout.row(align=True)
+
+            # PointLight 생성버튼
             col = row.column()
             col.operator(
                 AddPointLightOperator.bl_idname, text="Point", icon="LIGHT_POINT"
@@ -215,7 +216,7 @@ class LightPanel(bpy.types.Panel):
                 row = layout.row(align=True)
                 row.prop(light, "color", text="Color", slider=True)
                 row = layout.row(align=True)
-                row.prop(light, "power", text="Power", slider=True)
+                row.prop(light, "energy", text="Energy", slider=True)
                 row = layout.row(align=True)
                 row.prop(light, "diffuse_factor", text="Diffuse", slider=True)
                 row = layout.row(align=True)
@@ -237,7 +238,7 @@ class AddLightOperatorBase(bpy.types.Operator):
         self.scene = bpy.context.scene
         return self.execute(context)
 
-    def __generate_light_name(self) -> str:
+    def _generate_light_name(self) -> str:
         # set default name
         name = "ACON_light"
 
@@ -257,7 +258,7 @@ class AddLightOperatorBase(bpy.types.Operator):
 
         return name
 
-    def __create_light_on_scene(self, light_name: str):
+    def _create_light_on_scene(self, light_name: str):
         acon_light_data: Light = bpy.data.lights.new(light_name, type=self.light_type)
         acon_light_data.energy = 10
 
@@ -266,8 +267,8 @@ class AddLightOperatorBase(bpy.types.Operator):
         return acon_light
 
     def execute(self, context):
-        light_name = self.__generate_light_name()
-        light = self.__create_light_on_scene(light_name)
+        light_name = self._generate_light_name()
+        light = self._create_light_on_scene(light_name)
         self.scene.collection.objects.link(light)
         item = self.scene.ACON_prop.lights.add()
         item.obj = light

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -200,8 +200,9 @@ class LightPanel(bpy.types.Panel):
             col = row.column()
             col.operator(RemoveLightOperator.bl_idname, text="", icon="REMOVE")
 
-            if scene_prop.lights and bpy.data.lights:
-                light_prop = bpy.data.lights[0].ACON_prop
+            if scene_prop.lights:
+                index = scene_prop.light_index
+                light_prop = scene_prop.lights[index].ACON_prop
                 row = layout.row(align=True)
                 row.prop(light_prop, "color", text="Color", slider=False)
                 row = layout.row(align=True)
@@ -289,23 +290,21 @@ class RemoveLightOperator(bpy.types.Operator):
 
     scene: bpy.types.Scene
 
-    def invoke(self, context, event):
-        if not bpy.context.scene:
+    def execute(self, context):
+        scene = context.scene
+        index = scene.ACON_prop.light_index
+        lights = scene.ACON_prop.lights
+
+        if not index in range(0,len(lights)):
             return {"FINISHED"}
 
-        self.scene = bpy.context.scene
-        return self.execute(context)
-
-    def execute(self, context):
-        index = self.scene.ACON_prop.light_index
-        light_obj = self.scene.ACON_prop.lights[index].obj
+        light_obj = scene.ACON_prop.lights[index].obj
 
         # 실제 오브젝트 제거 (data block 정리는 블렌더가 함)
         bpy.data.objects.remove(light_obj)
 
         # ACON_prop.lights 데이터 제거
-        self.scene.ACON_prop.lights.remove(index)
-
+        scene.ACON_prop.lights.remove(index)
 
         return {"FINISHED"}
 

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -160,10 +160,6 @@ class LightPanel(bpy.types.Panel):
     def __init__(self):
         super().__init__()
 
-    def draw_header(self, context):
-        layout = self.layout
-        layout.prop(context.scene.ACON_prop, "toggle_lights", icon="LIGHT", text="")
-
     def draw(self, context):
         # update scene
         scene = context.scene
@@ -203,8 +199,13 @@ class LightPanel(bpy.types.Panel):
             col = row.column()
             col.operator(RemoveLightOperator.bl_idname, text="", icon="REMOVE")
 
+
             if scene_prop.lights:
                 index = scene_prop.light_index
+
+                if index not in range(0,len(scene_prop.lights)):
+                    return
+
                 light = scene_prop.lights[index]
                 row = layout.row(align=True)
                 row.prop(light, "color", text="Color", slider=True)

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -136,8 +136,10 @@ class LIGHT_UL_List(bpy.types.UIList):
             self, context, layout, data, item, icon, active_data, active_propname
     ):
         if self.layout_type in {"DEFAULT", "COMPACT"}:
-            row = layout.row(align=True)
+            if not item.obj.data:
+                return
             light_type = item.obj.data.type
+            row = layout.row(align=True)
             obj = item.obj
             if light_type == 'POINT':
                 row.label(icon='LIGHT_POINT', text=obj.name)

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -149,6 +149,7 @@ class LIGHT_UL_List(bpy.types.UIList):
                 row.label(icon='LIGHT_AREA', text=obj.name)
             row.prop(item, "hide", text="", icon='HIDE_ON' if item.hide else 'HIDE_OFF')
 
+
 class LightPanel(bpy.types.Panel):
     bl_parent_id = "ACON_PT_Styles"
     bl_idname = "ACON3D_PT_Lights"
@@ -157,6 +158,7 @@ class LightPanel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_translation_context = "abler"
+
     def __init__(self):
         super().__init__()
 
@@ -199,11 +201,10 @@ class LightPanel(bpy.types.Panel):
             col = row.column()
             col.operator(RemoveLightOperator.bl_idname, text="", icon="REMOVE")
 
-
             if scene_prop.lights:
                 index = scene_prop.light_index
 
-                if index not in range(0,len(scene_prop.lights)):
+                if index not in range(0, len(scene_prop.lights)):
                     return
 
                 light = scene_prop.lights[index]
@@ -217,7 +218,6 @@ class LightPanel(bpy.types.Panel):
                 row.prop(light, "specular_factor", text="Specular", slider=True)
                 row = layout.row(align=True)
                 row.prop(light, "volume_factor", text="Volume", slider=True)
-
 
 
 class AddLightOperatorBase(bpy.types.Operator):
@@ -259,7 +259,8 @@ class AddLightOperatorBase(bpy.types.Operator):
 
         # object 생성
         acon_light: Object = bpy.data.objects.new(light_name, acon_light_data)
-        return(acon_light)
+        return (acon_light)
+
     def execute(self, context):
         light_name = self.__generate_light_name()
         light = self.__create_light_on_scene(light_name)
@@ -286,6 +287,7 @@ class AddAreaLightOperator(AddLightOperatorBase):
     bl_label = "Add Area Light"
     light_type = 'AREA'
 
+
 class RemoveLightOperator(bpy.types.Operator):
     bl_idname = "acon3d.remove_light"
     bl_label = "Remove Light"
@@ -297,7 +299,7 @@ class RemoveLightOperator(bpy.types.Operator):
         index = scene.ACON_prop.light_index
         lights = scene.ACON_prop.lights
 
-        if not index in range(0,len(lights)):
+        if not index in range(0, len(lights)):
             return {"FINISHED"}
 
         light_obj = scene.ACON_prop.lights[index].obj
@@ -309,6 +311,7 @@ class RemoveLightOperator(bpy.types.Operator):
         scene.ACON_prop.lights.remove(index)
 
         return {"FINISHED"}
+
 
 class ShadowShadingPanel(bpy.types.Panel):
     bl_parent_id = "ACON_PT_Styles"

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -141,13 +141,13 @@ class LIGHT_UL_List(bpy.types.UIList):
             light_type = item.obj.data.type
             row = layout.row(align=True)
             obj = item.obj
-            if light_type == 'POINT':
+            if light_type == "POINT":
                 row.label(icon='LIGHT_POINT', text=obj.name)
-            elif light_type == 'SPOT':
+            elif light_type == "SPOT":
                 row.label(icon='LIGHT_SPOT', text=obj.name)
-            elif light_type == 'AREA':
+            elif light_type == "AREA":
                 row.label(icon='LIGHT_AREA', text=obj.name)
-            row.prop(item, "hide", text="", icon='HIDE_ON' if item.hide else 'HIDE_OFF')
+            row.prop(item, "is_hidden", text="", icon='HIDE_ON' if item.is_hidden else "HIDE_OFF")
 
 
 class LightPanel(bpy.types.Panel):
@@ -158,9 +158,6 @@ class LightPanel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_translation_context = "abler"
-
-    def __init__(self):
-        super().__init__()
 
     def draw(self, context):
         # update scene
@@ -223,9 +220,7 @@ class LightPanel(bpy.types.Panel):
 class AddLightOperatorBase(bpy.types.Operator):
     bl_options = {"REGISTER"}
     bl_translation_context = "abler"
-    bl_idname: bpy.props.StringProperty()
-    bl_label: bpy.props.StringProperty()
-    light_type = 'LIGHT_BASE'
+    light_type = "LIGHT_BASE"
     scene: bpy.types.Scene
 
     def invoke(self, context, event):
@@ -235,9 +230,9 @@ class AddLightOperatorBase(bpy.types.Operator):
         self.scene = bpy.context.scene
         return self.execute(context)
 
-    def __generate_light_name(self):
+    def __generate_light_name(self) -> str:
         # set default name
-        name = "ACON_" + "_light"
+        name = "ACON_light"
 
         # while 여러번 돌 수 있으므로. reference로 리스트를 먼저 한번 생성해준다.
         light_names = [obj.name for obj in self.scene.collection.objects if obj.type == 'LIGHT']
@@ -253,7 +248,7 @@ class AddLightOperatorBase(bpy.types.Operator):
 
         return name
 
-    def __create_light_on_scene(self, light_name: bpy.props.StringProperty(name="Light Name")):
+    def __create_light_on_scene(self, light_name: str):
         acon_light_data: Light = bpy.data.lights.new(light_name, type=self.light_type)
         acon_light_data.energy = 10
 
@@ -273,19 +268,19 @@ class AddLightOperatorBase(bpy.types.Operator):
 class AddPointLightOperator(AddLightOperatorBase):
     bl_idname = "acon3d.add_light_point"
     bl_label = "Add Point Light"
-    light_type = 'POINT'
+    light_type = "POINT"
 
 
 class AddSpotLightOperator(AddLightOperatorBase):
     bl_idname = "acon3d.add_light_spot"
     bl_label = "Add Spot Light"
-    light_type = 'SPOT'
+    light_type = "SPOT"
 
 
 class AddAreaLightOperator(AddLightOperatorBase):
     bl_idname = "acon3d.add_light_area"
     bl_label = "Add Area Light"
-    light_type = 'AREA'
+    light_type = "AREA"
 
 
 class RemoveLightOperator(bpy.types.Operator):
@@ -380,9 +375,7 @@ class ShadingPanel(bpy.types.Panel):
 
 
 class MATERIAL_UL_List(bpy.types.UIList):
-    def draw_item(
-            self, context, layout, data, item, icon, active_data, active_propname
-    ):
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
         layout.use_property_split = True
         layout.use_property_decorate = False
         ob = data

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -239,7 +239,9 @@ class AddLightOperatorBase(bpy.types.Operator):
         return self.execute(context)
 
     def _create_light_on_scene(self):
-        acon_light_data: Light = bpy.data.lights.new(name="ACON_light", type=self.light_type)
+        acon_light_data: Light = bpy.data.lights.new(
+            name="ACON_light", type=self.light_type
+        )
         acon_light_data.energy = 10
 
         # object 생성

--- a/source/blender/draw/engines/overlay/overlay_engine.c
+++ b/source/blender/draw/engines/overlay/overlay_engine.c
@@ -445,33 +445,11 @@ static void OVERLAY_cache_populate(void *vedata, Object *ob)
         break;
     }
   }
-  /* Non-Meshes */
-  if (draw_extras) {
-    switch (ob->type) {
-      case OB_EMPTY:
-        OVERLAY_empty_cache_populate(vedata, ob);
-        break;
-      case OB_LAMP:
-        OVERLAY_light_cache_populate(vedata, ob);
-        break;
-      case OB_CAMERA:
-        OVERLAY_camera_cache_populate(vedata, ob);
-        break;
-      case OB_SPEAKER:
-        OVERLAY_speaker_cache_populate(vedata, ob);
-        break;
-      case OB_LIGHTPROBE:
-        OVERLAY_lightprobe_cache_populate(vedata, ob);
-        break;
-      case OB_LATTICE: {
-        /* Unlike the other types above, lattices actually have a bounding box defined, so hide the
-         * lattice wires if only the bounding-box is requested. */
-        if (ob->dt > OB_BOUNDBOX) {
-          OVERLAY_lattice_cache_populate(vedata, ob);
-        }
-        break;
-      }
-    }
+
+  /* [modification of Overlay Logic for ABLER viewport] */
+  /* only overlay light objects (except sun) when show_extras is enabled */
+  if (draw_extras && ob->type == OB_LAMP) {
+      OVERLAY_light_cache_populate(vedata, ob);
   }
 
   if (!BLI_listbase_is_empty(&ob->particlesystem)) {

--- a/source/blender/draw/engines/overlay/overlay_engine.c
+++ b/source/blender/draw/engines/overlay/overlay_engine.c
@@ -448,8 +448,16 @@ static void OVERLAY_cache_populate(void *vedata, Object *ob)
 
   /* [modification of Overlay Logic for ABLER viewport] */
   /* only overlay light objects (except sun) when show_extras is enabled */
-  if (draw_extras && ob->type == OB_LAMP) {
-      OVERLAY_light_cache_populate(vedata, ob);
+  /* Non-Meshes */
+  if (draw_extras) {
+      switch (ob->type) {
+          case OB_LAMP:
+              OVERLAY_light_cache_populate(vedata, ob);
+              break;
+          case OB_CAMERA:
+              OVERLAY_camera_cache_populate(vedata, ob);
+              break;
+      }
   }
 
   if (!BLI_listbase_is_empty(&ob->particlesystem)) {

--- a/source/blender/draw/engines/overlay/overlay_extra.c
+++ b/source/blender/draw/engines/overlay/overlay_extra.c
@@ -654,9 +654,6 @@ void OVERLAY_light_cache_populate(OVERLAY_Data *vedata, Object *ob)
     instdata.area_size_x = instdata.area_size_y = la->area_size;
     DRW_buffer_add_entry(cb->light_point, color, &instdata);
   }
-  else if (la->type == LA_SUN) {
-    DRW_buffer_add_entry(cb->light_sun, color, &instdata);
-  }
   else if (la->type == LA_SPOT) {
     /* Previous implementation was using the clipend distance as cone size.
      * We cannot do this anymore so we use a fixed size of 10. (see T72871) */


### PR DESCRIPTION
## 발제/내용
* 기존 에이블러에서는 싱글톤 태양 광원만 있었고, 이 광원에 대한 프로퍼티 수정만 가능했었음 
* 유저 커스텀 조명에 대한 기능이 필요한 상황

## 대응
### 어떤 조치를 취했나요?

* 유저 커스텀으로 조명을 추가,제거 할 수 있는 기능 개발
* Area, Spot, Point 타입의 조명 지원
* 스타일 탭에서 Lights 패널을 통해서 UI리스트 제공
* UI 리스트에서 각 세부조명에 대한 hide, 프로퍼티 수정(컬러,볼륨,디퓨즈,반사,확산), 조명 삭제 기능 제공
* (블렌더 코드) 조명 UI 트랜스포메이션을 적용하려면 오버레이에서 show_extras 활성화가 필요함, 하지만 이렇게 하면 불필요한 empty object들도 같이 보이기 때문에 영향 최소화를 위해 overlay 코드 수정


### 개발 도중 진행한 이슈
* 백그라운드가 제대로 적용되지 않는 상황 => 블렌더 오버레이 로직을 수정하면서 camera overlay 도 OFF 했는데, 해당 부분에서 백그라운드도 관리하고있었음. 따라서 삭제작업을 원복함
* 유저가 delete, X키를 통해 삭제할 시, UI와 실제 오브젝트 리스트 정합성이 안맞는 상황 => depsgraph_update_post 핸들러에 업데이트 함수 추가함 (자주 호출되어서 성능이 염려되어서 필터링 로직 추가함)

## 리뷰 및 테스트에서 중점적으로 다루면 좋은 사항
* 조명 추가,제거 후 저장,불러오기