### PR TITLE
SWTASK-285 업데이터 버그 수정

### DIFF
--- a/release/darwin/ABLER.app/Contents/Info.plist
+++ b/release/darwin/ABLER.app/Contents/Info.plist
@@ -91,7 +91,7 @@
     <string>${SPARKLE_PUBLIC_ED_KEY}</string>
 	<key>SUFeedURL</key>
     <string>${SPARKLE_FEED_ADDRESS}</string>
-    <key>SUEnableAutomaticChecks</key>
-	<true/>
+	<key>SUEnableInstallerLauncherService</key>
+    <true/>
 </dict>
 </plist>

--- a/release/darwin/ABLER_macOS_Release.sh
+++ b/release/darwin/ABLER_macOS_Release.sh
@@ -66,7 +66,7 @@ if ! "${testing}"; then
     done
 
     # bundle.sh 실행
-    sh ./bundle.sh --source "${_mount_dir}" --dmg "${_dmg_dir}" --bundle-id com.acon3d.abler.release --username global@acon3d.com --password "@keychain:altool-password" --codesign "${_codesign_cert}"
+    sh ./bundle.sh --source "${_mount_dir}" --dmg "${_dmg_dir}" --bundle-id com.acon3d.abler.release --username global@acon3d.com --password "@keychain:altool-password" --codesign "${_codesign_cert}" --sparkle-dir "${SPARKLE_DIR}"
 else
     # qt 기본 제공 번들러
     macdeployqt ${_mount_dir}/ABLER.app -verbose=3
@@ -82,7 +82,7 @@ else
     done
 
     # bundle.sh 실행
-    sh ./bundle.sh --source "${_mount_dir}" --dmg "${_dmg_dir}" --bundle-id com.acon3d.abler.release --username global@acon3d.com --password "@keychain:altool-password" --codesign "${_codesign_cert}" --test
+    sh ./bundle.sh --source "${_mount_dir}" --dmg "${_dmg_dir}" --bundle-id com.acon3d.abler.release --username global@acon3d.com --password "@keychain:altool-password" --codesign "${_codesign_cert}" --sparkle-dir "${SPARKLE_DIR}" --test
 fi
 
 # generate_appcast_and_image.sh 실행

--- a/release/darwin/entitlements.plist
+++ b/release/darwin/entitlements.plist
@@ -11,5 +11,11 @@
   <!-- For LLVM. -->
   <key>com.apple.security.cs.allow-jit</key>
   <true/>
+  <!-- For Sparkle -->
+  <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+  <array>
+    <string>com.acon3d.abler.release-spks</string>
+    <string>com.acon3d.abler.release-spki</string>
+  </array>
 </dict>
 </plist>

--- a/release/darwin/generate_appcast_and_image.sh
+++ b/release/darwin/generate_appcast_and_image.sh
@@ -46,7 +46,7 @@ cd "${_work_dir}"
 echo "Moving old versions..."
 
 mkdir -p ./old_versions
-mv ./*.dmg ./old_versions
+find . -name "ABLER_MacOS_*.dmg" -exec mv {} ./old_versions \;
 mv ./*.xml ./old_versions
 
 # Generate appcast

--- a/source/creator/CMakeLists.txt
+++ b/source/creator/CMakeLists.txt
@@ -1056,6 +1056,7 @@ elseif(APPLE)
   install(
     DIRECTORY "${SPARKLE_DIR}/Sparkle.framework"
     DESTINATION "${MAC_BLENDER_TARGET_DYLIBS_DIR}"
+    USE_SOURCE_PERMISSIONS
   )
 
   # Gather the date in finder-style


### PR DESCRIPTION
## 관련 링크
[이슈](https://carpenstreet.atlassian.net/browse/SWTASK-285?atlOrigin=eyJpIjoiNTkxNmRlZTYyZDU5NDFlM2E3NGI0MzQzOTA0ZDE2ZGYiLCJwIjoiaiJ9)
[Sparkle Sandboxing 문서](https://sparkle-project.org/documentation/sandboxing/)

## 발제/내용

- 업데이트가 되지 않는 버그를 수정하였습니다.


## 대응

### 어떤 조치를 취했나요?

-  Cmake 에서 Sparkle 패키지를 설치하는 과정에 `USE_SOURCE_PERMISSIONS` 을 추가하여 실행 파일들이 원래 권한대로 추가되도록 변경
- Sandboxed 앱 관련 Sparkle 설정
  - info.plist. 에 `SUEnableInstallerLauncherSerivce` 추가
  - UPDATE entitlements.plist
- 에이블러 메인 번들 코드사인 시 deep, force 플래그 제거, 외부 패키지에 에이블러의 entitlements 들어가지 않도록 제거
- Sparkle 프레임워크 코드사인 시 명확한 조건 추가 및 변수 추가
- dmg 파일에 옮겨지지 않던 generate_appcast_and_image 파일 수정