### PR TITLE
SWTASK-288 .blend 파일의 버전이 현 프로그램의 버전보다 높을 때 업데이트가 되지 않는 오류

### DIFF
--- a/intern/ghost/GHOST_C-api.h
+++ b/intern/ghost/GHOST_C-api.h
@@ -951,6 +951,8 @@ extern void GHOST_EndIME(GHOST_WindowHandle windowhandle);
 // ABLER: Updater for MacOS
 #if defined(__APPLE__)
 extern void GHOST_CreateAndCheckSparkleUpdater(GHOST_SystemHandle systemhandle);
+
+extern void GHOST_CheckSparkleUpdater(GHOST_SystemHandle systemhandle);
 #endif
 
 #ifdef WITH_XR_OPENXR

--- a/intern/ghost/intern/GHOST_C-api.cpp
+++ b/intern/ghost/intern/GHOST_C-api.cpp
@@ -55,6 +55,12 @@ void GHOST_CreateAndCheckSparkleUpdater(GHOST_SystemHandle systemhandle)
   system->createSparkleUpdater();
   system->sparkleCheckForUpdates();
 }
+
+void GHOST_CheckSparkleUpdater(GHOST_SystemHandle systemhandle)
+{
+  GHOST_ISystem *system = (GHOST_ISystem *)systemhandle;
+  system->sparkleCheckForUpdates();
+}
 #endif
 
 void GHOST_SystemInitDebug(GHOST_SystemHandle systemhandle, int is_debug_enabled)

--- a/intern/ghost/intern/GHOST_ISystem.cpp
+++ b/intern/ghost/intern/GHOST_ISystem.cpp
@@ -121,14 +121,12 @@ void GHOST_ISystem::createSparkleUpdater()
   }
 }
 
-// ABLER: Updater for MacOS
 void GHOST_ISystem::disposeSparkleUpdater()
 {
   delete sparkleUpdater;
   sparkleUpdater = NULL;
 }
 
-// ABLER: Updater for MacOS
 void GHOST_ISystem::sparkleCheckForUpdates()
 {
   sparkleUpdater->checkForUpdates();

--- a/source/blender/makesrna/intern/rna_wm_api.c
+++ b/source/blender/makesrna/intern/rna_wm_api.c
@@ -783,6 +783,12 @@ void RNA_api_window(StructRNA *srna)
   RNA_def_boolean(func, "oskey", 0, "OS Key", "");
   parm = RNA_def_pointer(func, "event", "Event", "Item", "Added key map item");
   RNA_def_function_return(func, parm);
+
+// ABLER: Updater for MacOS
+#if defined(__APPLE__)
+  RNA_def_function(srna, "check_sparkle_updater", "WM_check_sparkle_updater");
+  RNA_def_function_ui_description(func, "Check Sparkle Updater");
+#endif
 }
 
 void RNA_api_wm(StructRNA *srna)

--- a/source/blender/windowmanager/WM_api.h
+++ b/source/blender/windowmanager/WM_api.h
@@ -252,6 +252,11 @@ void WM_paint_cursor_tag_redraw(struct wmWindow *win, struct ARegion *region);
 void WM_cursor_warp(struct wmWindow *win, int x, int y);
 void WM_cursor_compatible_xy(wmWindow *win, int *x, int *y);
 
+// ABLER: Updater for MacOS
+#if defined(__APPLE__)
+void WM_check_sparkle_updater(struct wmWindow *win);
+#endif
+
 /* handlers */
 
 typedef bool (*EventHandlerPoll)(const ARegion *region, const struct wmEvent *event);

--- a/source/blender/windowmanager/intern/wm_window.c
+++ b/source/blender/windowmanager/intern/wm_window.c
@@ -1589,6 +1589,17 @@ void wm_window_process_events(const bContext *C)
  * \note #bContext can be null in background mode because we don't
  * need to event handling.
  */
+
+// ABLER: Updater for MacOS
+#if defined(__APPLE__)
+void WM_check_sparkle_updater(wmWindow *win)
+{
+  if (win && win->ghostwin) {
+    GHOST_CheckSparkleUpdater(g_system);
+  }
+}
+#endif
+
 void wm_ghost_init(bContext *C)
 {
   if (!g_system) {


### PR DESCRIPTION
## 관련 링크
[이슈](https://carpenstreet.atlassian.net/browse/SWTASK-288?atlOrigin=eyJpIjoiMTJmMTBjYTMwNTNhNDRjYzlmNWY4ZDdhM2ZlMWM5ODEiLCJwIjoiaiJ9)
[QA 이슈](https://carpenstreet.atlassian.net/browse/SW-59?atlOrigin=eyJpIjoiYWJmNDRiMWE2ODQ1NGM1ZGJmN2UzZjNiZTViOTk2MmEiLCJwIjoiaiJ9)

## 발제/내용

- 더 높은 에이블러 버전에서 저장된  .blend 파일을 열 때, Update ABLER 창이 나오는데, 해당 버튼을 누르면 에러가 발생한다. Sparkle 업데이터에 연결되어야 함.

## 대응

### 어떤 조치를 취했나요?

- `check_sparkle_updater` 함수를 추가하여 bpy 파이썬 모듈에서 쓸 수 있도록 함
- `Acon3dUpdateAblerOperator` 의 `execute` 함수를 os 별로 대응
-  Sparkle 업데이터를 `Acon3dUpdateAblerOperator` 에 연결
- `is_window` -> `is_windows` 변경
- 필요없는 주석 삭제