### PR TITLE
SWTASK-320 DMG에 EULA 넣기

### DIFF
--- a/release/darwin/README_EULA.txt
+++ b/release/darwin/README_EULA.txt
@@ -1,0 +1,197 @@
+에이블러 이용약관
+
+제1조 목적
+본 소프트웨어 사용권 계약(이하 "본 계약")은 주식회사 카펜스트리트(이하 “회사”)의 소프트웨어 제품(이하 “에이블러”)의 사용과 관련하여 귀하와 회사 간의 제반 권리, 의무와 관련 절차 및 책임사항 등을 규정하는데 그 목적이 있습니다.
+
+제2조 용어의 정의
+이 약관에서 사용하는 용어의 정의는 다음 각 항과 같으며, 정의되지 않은 용어에 대한 해석은 관계법령 및 다운로드처 내 별도 안내에서 정하는 바에 따릅니다.
+1)에이블러: 본 계약에서 “에이블러”란 회사가 오픈소스 3D 소프트웨어 블렌더 기반으로 하여 제공하는 3D 소프트웨어입니다. 본 사용권 계약 사항은 “에이블러”의 사용법 관련 문서, 수정된 버전, 업그레이드 또는 개선 기능, 그러한 소프트웨어의 모든 후속 버전, 사본을 포함합니다.
+2)에이콘3D: 에이콘3D란 “에이블러”의 로그인 서버를 관제하는 웹플랫폼입니다.
+3)사용자: 사용자란 본 계약에 동의한 후 에이콘3D의 계정을 이용하여 “에이블러”를 설치하고 이용하는 이용 고객을 의미합니다.
+4)모델: 에이블러에서 사용할 수 있는 3D 모델의 일체를 가리키며, 1차 제작자에게 저작권이 있는 작업물을 지칭합니다.
+
+제3조 오픈소스 라이선스
+1)에이블러는 오픈소스 라이선스인 GPL 3.0을 따르며, 이용의 범위 또한 GPL3.0과 동일합니다.
+2)오픈소스 소프트웨어의 개별 라이선스 조건 및 관련 문서, 기타 자료, 저작권 표시 등 세부사항은 에이블러에서 제공되는 설치 파일 내 라이선에서 확인할 수 있으며, 이는 해당 라이선스 허가권자에 의해 별도의 고지나 통지 없이 변경될 수 있습니다. 단, 이미 에이블러를 설치한 사용자에게는 업데이트 사항 안내를 통해 변경 내용을 고지하며 변경된 내용에 동의하지 않는 경우 서비스 이용이 제한될 수 있습니다.
+3)오픈소스 소프트웨어의 라이선스 조건과 본 계약의 내용이 상충하는 경우, 그 범위에 한하여 오픈소스 소프트웨어의 라이선스 조건이 우선됩니다.
+4)오픈소스 소프트웨어는 유용한 사용을 위해 배포되고 있지만 특정한 목적에의 적합성 여부나 판매용으로 사용할 수 있다는 묵시적인 보증을 포함한 어떠한 형태의 보증도 제공하지 않습니다.
+5)오픈소스 소프트웨어의 라이선스 허가권자, 회사, 공급자 등은 사용자의 오픈소스 소프트웨어 사용으로 발생하는 일체의 손해에 대해, 그 손해 발생 가능성을 사전에 알고 있었다 하더라도, 관련 법률이 허용하는 최대한의 범위에서 어떠한 책임도 부담하지 않습니다.
+
+제4조 인터넷 기반 서비스 제공
+1)에이블러는 에이콘3D 계정으로 로그인하는 과정에서 서버와의 통신을 실행합니다.
+2)에이블러는 업데이트를 위한 정상적 작동의 일부로서 인터넷을 통해 통신을 실행하는 기능이 포함되어 있습니다.
+3)에이블러가 업데이트할 경우 필요에 따라 사용자의 동의 없이 임의의 파일이 사용자의 컴퓨터에 설치될 수 있습니다. 사용자의 컴퓨터에 대한 업데이트를 강화하기 위해 업데이트 방식은 언제든지 변경될 수 있습니다.
+4)회사는 에이블러의 품질 및 성능 개선을 위하여 사용자의 에이블러 사용 과정에서 발견된 다음 각 호의 정보를 수집할 수 있습니다.
+   (1) 사용자의 컴퓨터 운영체제 및 운영체제에 등록된 정보, 에이블러의 버전, 에러 정보와 같이 개인을 식별할 수 없는 비 개인 식별 정보
+   (2) 프로그램의 사용성 개선을 위한 사용자의 프로그램 내 사용 패턴과 상호작용에 대한 정보
+   (3) 국가/지역별 맞춤 언어 제공 및 국가별 이용 패턴 확인을 위한 IP정보
+5)회사는 개인정보보호법 등 관련 법규를 준수하며, 원칙적으로 수집한 정보를 외부에 전달하거나 공개하지 않습니다. 다만, 아래의 경우는 예외로 하며, 기재된 내용 외에 이용자의 개인정보를 제공 혹은 공유하는 경우에는 별도로 이용자의 동의를 구한 후 해당 정보를 제공합니다.
+   (1) 법령의 규정에 의거한 경우, 수사 목적으로 법령에 정해진 절차와 방법에 따라 수사기관의 요구가 있는 경우
+   (2) 통계 작성, 학술 연구, 시장 조사를 위해 특정 개인을 식별할 수 없는 형태로 가공해서 제공하는 경우
+   (3) 이용자가 사전에 동의한 경우
+6)수집된 정보는 서비스 사용 종료 후 1년간 보관되며, 해당 기간이 종료된 이후 회사는 기록을 재생할 수 없는 기술적 방법을 사용하여 전자적 파일 형태로 저장된 개인정보를 삭제합니다. 종이에 출력된 개인정보는 분쇄나 소각을 통해 파기됩니다.
+7)상세한 개인정보 처리 방침은 다음의 웹사이트에서 안내합니다. https://www.acon3d.com/ko/toon/policy/privacy
+
+
+제5조 이용약관의 효력 및 변경
+1)본 약관은 사용자의 약관 동의로 효력이 발생합니다.
+2)회사는 "약관의 규제에 관한 법률", "정보통신망 이용촉진 및 정보보호 등에 관한 법률",“온라인 디지털콘텐츠산업 발전법”등 관련법을 위배하지 않는 범위에서 본 약관을 개정할 수 있으며, 개정된 내용을 사용자들에게 공지합니다.
+3)본 약관은 필요 시 개정될 수 있으며 약관을 개정하고자 할 경우, 회사는 개정된 약관을 적용 일자 및 개정사유를 명시하여 현행약관과 함께 그 개정약관의 적용일자 14일 이전부터
+적용 일자 전일까지 공지합니다. 개정약관의 공지는 규정된 방법 중 1가지 이상의 방법으로 사용자에게 명확하게 공지하도록 합니다. 다만, 사용자의 권리 또는 의무에 관한 중요한 규정의 변경은 최소한 30일 전에 공지하고 개정약관을 사용자가 등록한 이메일 등으로 발송하여 통지합니다.
+   (1)웹사이트 내 게시
+   (2)E-mail 통보
+   (3)회사가 정한 기타 공지 방법 등
+4)본 조의 규정에 따라 개정약관은 원칙적으로 그 효력 발생일로부터 장래를 향하여 유효합니다.
+5)사용자가 개정약관의 적용에 동의하지 않는 경우 에이블러를 삭제함으로써 이용계약을 해지할 수 있습니다.
+
+제6조 지식재산권
+1)회사가 작성한 저작물에 대한 저작권 기타 지적재산권은 회사에 귀속합니다. 단, 작성을 위하여 제공 받은 모델 등의 작업물은 1차 제작자에게 저작권이 있으며, 회사 및 사용자는 이에 대한 사용권을 가집니다.
+2) 사용자가 에이블러를 이용하여 창작한 저작물에 대한 저작권은 사용자에게 귀속됩니다. 단, 이 경우 원저작자가 있는 저작물의 저작권은 원저작자에게 귀속되고 사용자는 창작한 저작물을 복제, 전시, 배포할 수 있는 영구적인 사용권을 가집니다.
+
+제7조 서비스의 제공 및 소프트웨어의 유지 관리
+1)회사는 관련법과 이 약관이 금지하거나 미풍양속에 반하는 행위를 하지 않으며, 계속적이고 안정적으로 에이블러를 제공하기 위하여 최선을 다하여 노력합니다.
+2)회사는 사용자가 안전하게 에이블러를 이용할 수 있도록 개인정보보호를 위해 보안시스템을 갖추어야 하며 개인정보취급방침을 공시하고 준수합니다.
+3)회사는 에이블러이용과 관련하여 사용자로부터 제기된 의견이나 불만이 정당하다고 인정할 경우에는 이를 처리하여야 합니다. 사용자가 제기한 의견이나 불만사항에 대해서는 전자우편 등을 통하여 사용자에게 처리 과정 및 결과를 전달합니다.
+4)에이블러 제공은 회사의 업무상 또는 기술상 특별한 지장이 없는 한 연중무휴, 1일 24시간 운영을 원칙으로 합니다. 단, 회사는 시스템 정기점검, 증설 및 교체를 위해 회사가 정한 날이나 시간에 서비스를 일시 중단할 수 있으며, 예정된 작업으로 인한 서비스 일시 중단은 홈페이지를 통해 사전에 공지합니다.
+5)회사는 국가비상사태, 정전, 설비의 장애 또는 이용의 폭주 등으로 정상적인 서비스 제공이 불가능할 경우, 에이블러의 전부 또는 일부를 제한하거나 중지할 수 있습니다. 다만 이 경우 그 사유 및 기간 등을 사용자에게 사전 또는 사후에 공지합니다.
+6)회사는 에이블러를 특정범위로 분할하여 각 범위별로 이용 가능 시간을 별도로 지정할 수 있습니다. 다만 이 경우 그 내용을 공지합니다.
+7)회사는 에이블러 설치 시 제공되는 업데이트 기능을 통해 에이블러의 최신성 및 안정성 향상과 사용자 편의 도모를 위한 업데이트를 제공할 수 있습니다.
+8)업데이트의 상황에 따라 이미 제공된 에이블러의 기능 일부를 사용할 수 없는 경우가 발생할 수 있습니다.
+
+제8조 사용자의 의무
+1)사용자는 본 약관에서 규정하는 사항과 기타 회사가 정한 제반 규정, 공지사항 및 소프트웨어가 사용되는 지역의 관계 법령을 준수하여야 하며, 기타 회사의 업무에 방해가 되는 행위, 회사의 명예를 손상하는 행위를 해서는 안 됩니다.
+2)사용자는 에이블러를 제공하는 서버 등에 회사가 허락하지 않은 방법으로 접근을 시도해서는 안 됩니다.
+3)사용자는 에이블러의 활용에 1차 제작자가 저작권을 가지는 모델을 회사의 사전 승낙 없이 모델 자체로서 재배포, 판매 등의 방법으로 영리 목적으로 이용하거나 제3자에게 이용하게 하여서는 안 됩니다. 이를 적발 시에 회사는 에이블러의 이용제한 및 적법한 절차를 거쳐 손해배상 등을 청구할 수 있습니다.
+4) 사용자는 보호되는 콘텐츠 또는 기타 저작권을 보호하기 위한 기술적 조치를 회피하기 위해 설계된 장치, 소프트웨어 또는 서비스와 함께 에이블러를 사용할 수 없습니다.
+
+제9조 제한적 보증: 면책조항 및 책임의 배제
+1)회사는 관련 법률이 허용하는 최대한의 범위에서 상품성, 특정 목적에 대한 적합성, 지식재산권 또는 지식재산권의 비침해성에 대한 묵시적 보증 등을 포함한 명시적 또는 묵시적인 모든 보증을 배제합니다.
+2)회사는에이블러를 통하여 제공하는 콘텐츠 내용의 정확성 등의 여부에 관하여 책임을 지지 않습니다.
+3)회사는 약관, 서비스별 안내, 기타 회사가 정한 이용기준을 준수하지 않은 이용으로 인한 결과에 대하여 책임을 지지 않습니다.
+4)회사는 에이블러에 포함된 기능이 사용자의 요구사항을 모두를 충족시키거나 사용 시 컴퓨터의 사용에 일시적인 간섭이나 오류가 발생하지 않을 것을 보증하지 않습니다.
+5)사용자가 에이블러를 사용할 경우 사용자의 PC 상에 의도하거나 예상하지 못한 장애(진단오류, 컴퓨터의 기능 저하, 마비 또는 오동작 등)가 발생할 수 있으며, 사용자는 이러한 사항을 충분히 고려하여 에이블러의 사용을 결정해야 합니다. 이러한 장애 가능성에도 사용자가 에이블러를 사용함으로써 발생하는 장애에 대하여 회사의 고의 또는 중과실이 없는 한 책임을 지지 않습니다.
+6)회사는 에이블러가 제공된 이후에 제조된 컴퓨터 하드웨어와 컴퓨터 운영체제의 변경에 따라서 발생하는 문제에 관해 회사의 고의나 중과실이 없는 한 책임을 지지 않습니다.
+7)회사는 사용자가 에이블러를 이용하여 기대하는 수익을 얻지 못하거나 상실한 것에 관하여 책임을 지지 않습니다.
+8)회사는 사용자 상호 간 및 사용자와 제 3자 상호 간에 에이블러를 매개로 발생한 분쟁에 대해 개입하지 않으며, 이에 따른 손해에 대해 배상하지 않습니다.
+9)회사는 제공되는 에이블러와 관련해서는 관련법에 특별한 규정이 없는 한 책임지지 않습니다.
+10)회사는 다음 사유로 서비스를 제공할 수 없는 경우 이로 인하여 사용자에게 발생한 손해에 관해서는 책임을 지지 않습니다.
+   (1)천재지변 또는 이에 준하는 불가항력의 상태가 있는 경우
+   (2)서비스 제공을 위하여 회사와 서비스 제휴계약을 체결한 제3자의 고의적인 서비스 방해가 있는 경우
+   (3)디바이스 환경 등 사용자의 귀책사유로 서비스 이용에 장애가 있는 경우
+   (4)네트워크 환경 등 기타 회사의 고의,과실이 없는 사유로 인한 경우
+
+제10조 계약의 해지
+1)사용자는 언제든지 에이블러를 영구히 폐기함으로써 본 계약을 해지할 수 있습니다.
+2)회사는 제휴관계의 종료, 기타 서비스를 지속할 수 없는 중대한 사업적 이유 등을 원인으로 하여 에이블러의 제공을 중지할 수 있습니다.
+3)회사가 서비스를 종료하고자 할 경우, 회사는 서비스를 종료하고자 하는 날로부터 3개월 이전에 본 약관 제5조 제3항에 규정된 통지방법을 준용하여 사용자에게 알립니다.
+단, 서비스의 종료가 아닌 사업상 기타 운영상의 이유로 인한 양도는 특별히 공지하지 않습니다.
+
+제11조 손해배상
+1)사용자가 본 약관의 규정을 위반함으로 인하여 회사에 손해가 발생하게 되는 경우, 본 약관을 위반한 사용자는 회사에 발생하는 모든 손해를 배상하여야 합니다.
+2)사용자가 서비스를 이용하는 과정에서 행한 불법행위나 본 약관 위반행위로 회사가 당해 사용자 이외의 제 3자로부터 손해배상 청구 또는 소송을 비롯한 각종 이의제기를 받은 경우 당해 사용자는 자신의 책임과 비용으로 회사를 면책시켜야 하며, 회사가 면책되지 못한 경우 당해 사용자는 그로 인하여 회사에 발생한 모든 손해를 배상하여야 합니다.
+3)회사는 무료로 제공하는 서비스와 관련하여 발생하는 사항에 대하는 어떠한 손해도 책임을 지지 않습니다.
+
+제12조 서비스 관련 분쟁 해결
+1)회사는 서비스 이용과 관련하여 사용자로부터 제출되는 불만사항 및 의견을 최대한 신속하게 처리합니다. 다만, 신속한 처리가 곤란한 경우에는 사용자에게 그 사유와 처리일정을 조속히 통보합니다.
+2)회사와 사용자 간에 발생한 분쟁은 전자거래기본법에 의하여 설치된 전자거래분쟁 조정위원회의 조정절차를 거쳐 진행됩니다.
+3)본 약관에서 정하지 않은 사항과 본 약관의 해석에 관하여는 대한민국법 및 상관례에 따릅니다.
+4)서비스 및 본 약관과 관련한 제반 분쟁 및 소송은 서울중앙지방법원 또는 민사소송법상의 관할법원을 제1심 관할법원으로 합니다.
+
+
+ABLER Terms of Use
+
+Article 1 Purpose
+The purpose of this software usage rights agreement (hereafter "this Agreement") is to stipulate the rights, duties, relevant procedures, and responsibilities between you and Carpenstreet Inc. (hereafter "Company") with respect to using the Company's software product (hereafter "ABLER").
+
+Article 2 Definition of Terms
+The definition of terms used in these terms of use is as follows. The interpretation of terms not defined shall comply with relevant laws and separate guides on the download site.
+1) ABLER: "ABLER" in this Agreement refers to the 3D software that is provided by the Company based on the open-source 3D software Blender. The matters related to this usage rights agreement shall include all documents related to directions for using ABLER, revised versions, upgrades or improved features, and subsequent versions and copies of the software.
+2) ACON3D: ACON3D refers to the web platform that controls ABLER's login server.
+3) User: User refers to the customer who installs and uses ABLER by using an ACON3D account after agreeing to this Agreement.
+4) Model: Model refers to all 3D models that can be used on ABLER, and refers to products for which the primary creator has the copyrights to.
+
+Article 3 Open-Source License
+1) ABLER follows the open-source license GPL 3.0, and the scope of use is also the same as that of GPL 3.0.
+2) Details such as the individual license conditions of the open-source software, relevant documents, other materials, indication of copyrights, etc., can be found from the license within the installation file that ABLER provides, and are subject to change through the license authorizer without a separate announcement or notification. However, changes will be announced to users who already installed ABLER through updates, and service usage may be restricted if the user does not agree to the changes.
+3) If the open-source license conditions conflict with the content of this Agreement, the open-source license condition will take precedence limited to the relevant scope.
+4) Open-source software is distributed for beneficial use, but there are no guarantees, including implied guarantees that it is fit for a specific purpose or fit for sale.
+5) The open-source software license authorizer, company, supplier, etc., shall not be held responsible in any scope that is permitted by relevant laws for any damage that occurs due to a user's utilization of the open-source software, even if they were aware of the risk of such damage in advance.
+
+Article 4 Internet-based Service Provision
+1) ABLER communicates with the server through the process of logging into the ACON3D account.
+2) ABLER includes the function of communicating through the internet as part of normal operation for updates.
+3) If ABLER is updated, arbitrary files may be stored on the user's computer without the user's consent as needed. The update method is subject to change at any time in order to strengthen updates for the user's computer.
+4) The Company may collect the following information that is found during the user's process of using ABLER in order to improve the quality and performance of ABLER.
+   (1) The user's computer operating system, information registered on the operating system, ABLER version, error details, and other non-personally identifiable information.
+   (2) Information on the user's usage patterns and interaction within the program in order to improve the program's usability
+   (3) IP information to check usage patterns and provide customized languages for each country/region
+5) The Company is in compliance with the Personal Information Protection Act and other relevant laws, and does not share or disclose any information that is collected. However, the following are exceptions; if the user's personal information is provided or shared in cases other than in the following, the information will only be provided after obtaining the user's consent.
+   (1) If there is request from an investigative agency in accordance with the procedures and methods set forth by the law for investigative purposes
+   (2) If the information is provided after being processed in a way that makes it impossible to identify any specific individual for the purpose of statistics, academic research, or market research
+   (3) If the user gave consent in advance
+6) The information collected will be stored for 1 year after the end of service use. After this period, the Company shall delete personal information stored in the form of electronic files by using a technical method that will render the data irrecoverable. Personal information printed on paper shall be destroyed by shredding or incineration.
+7) A more detailed privacy policy is available on the website below. https://www.acon3d.com/en/toon/policy/privacy
+
+
+Article 5 Efficacy and Changes to the Terms of Use
+1)  These terms take effect when the user agrees to the terms.
+2) The Company may revise these terms within a scope that is not in violation of the "Act on the Regulation of Terms and Conditions," "Act on Promotion of Information and Communications Network Utilization and Information Protection," "Online Digital Contents Industry Promotion Act," and other relevant laws, and the changes shall be announced to users.
+3) These terms may be revised if necessary; if the terms are to be revised, the Company shall stipulate the effective date of the revised terms and reason for the revision, and make an announcement from at least 14 days before the effective date of the revised terms until the day before the effective date alongside the current terms. Announcements regarding the revised terms shall be announced clearly to users using at least one of the prescribed methods. However, for important changes to regulations related to the users' rights or duties, the changes shall be announced at least 30 days in advance, and the revised terms shall be sent to the e-mail that was registered by the user.
+   (1) Post on the website
+   (2) E-mail notification
+   (3) Other announcement methods determined by the Company
+4) In general, the revised terms shall be effective prospectively from the effective date in accordance with this Article.
+5) If the user does not consent to the revised terms, they may cancel the usage agreement by deleting ABLER.
+
+Article 6 Intellectual Property Rights
+1) The Company shall own copyrights and other intellectual property rights to works created by the Company. However, the copyright for products such as models, etc., that were provided to create the works shall belong to the primary creator, and the Company and user shall only have usage rights to these products.
+2) The user shall own the copyrights to works that were created by the user using ABLER. However, in this case, the copyright for works that have a primary creator shall belong to the primary creator, and the user shall have permanent usage rights to copy, display, and distribute the works that were created by the user.
+
+Article 7 Service Provision and Software Maintenance
+1) The Company shall not perform any activities that are prohibited by relevant laws or these terms and activities that go against public customs, and shall make the utmost effort to provide ABLER in a continuous and stable fashion.
+2) The Company must establish a security system in order to protect personal information so that the user can utilize ABLER safely, and shall announce and comply with the privacy policy.
+3) If the Company determines that an opinion or complaint submitted by the user in relation to using ABLER is valid, the Company shall take care of the issue. The Company shall notify the user of the process and results via e-mail, etc., for the opinion or complaint that they submitted.
+4) In general, the Company shall operate ABLER 24 hours a day, year-round, as long as there are no operational or technical issues. However, the Company may temporarily suspend services on a day or time specified by the Company in order to perform regular maintenance, expand, or replace the system, and the temporary service suspension for the scheduled task shall be announced in advance through the website.
+5) If the Company is unable to provide normal services due to a national emergency, power outage, equipment defect, or surge in use, the Company may restrict or suspend all or a portion of ABLER. However, in this case, the Company shall notify users of the reason and period of time in advance or afterward.
+6) The Company may divide ABLER into specific ranges and designate separate times when it can be used according to the range. However, the details shall be announced in such cases.
+7) The Company may provide updates through the update feature that is provided upon installing ABLER in order to maintain ABLER's recency, improve stability, and increase user convenience.
+8) Some features of ABLER that were previously available may no longer be used depending on the update circumstances.
+
+Article 8 User's Duties
+1) The user must comply with the regulations in these terms, all other regulations and announcements set forth by the Company, and relevant laws in the region where the software is used, and must not perform any activities that may disrupt the Company's work operations or may damage the Company's reputation.
+2) The user must not attempt to access the server, etc., that provides ABLER using a method that is not permitted by the Company.
+3) The user must not use a model for which the copyrights are owned by the primary creator for commercial purposes, such as redistribution or sales, without the Company's prior consent when using ABLER, nor allow a third party to use such models for commercial purposes. If such activities are discovered, the Company may restrict the use of ABLER and claim compensation for damages, etc., in accordance with the legal process.
+4) The user shall not use ABLER with devices, software, or services that were designed to evade technical measures to protect content or other copyrights.
+
+Article 9 Limited Warranty: Indemnification Clause and Exclusion of Liability
+1) The Company excludes all implicit and explicit guarantees, including implied guarantees regarding commercial value, fitness for a specific purpose, intellectual property rights, or non-violation of intellectual property rights to the maximum scope that is permitted by relevant laws.
+2) The Company shall not be held responsible for the accuracy of content that is provided through ABLER.
+3) The Company shall not be held responsible for anything that results from failing to abide by the terms, guides for each service, and other usage standards set forth by the Company.
+4) The Company does not guarantee that the features included in ABLER completely satisfy the user's demands, nor that there will not be any temporary interference or errors to computer usage while using ABLER.
+5) If the user utilizes ABLER, unintentional or unexpected defects may occur to the user's PC (diagnosis error, reduced computer functionality, freezing, malfunction, etc.), and the user must decide whether to use ABLER in consideration of this fact. The Company shall not be held responsible for any defects that occur as a result of using ABLER despite risk of such defects as long as it was not a result of the Company's intention or gross negligence.
+6) The Company shall not be held responsible for any problems that occur due to using computer hardware or computer operating systems that were produced after ABLER was provided as long as it was not a result of the Company's intention or gross negligence.
+7) The Company shall not be held responsible for the user's failure to earn the expected profits or loss of profits by using ABLER.
+8) The Company will not intervene in disputes that occur between users or between a user and a third party through ABLER, and shall not compensate for any resulting damages.
+9) The Company shall not be held responsible as long as there are no special regulations in relevant laws regarding ABLER.
+10) If the Company is unable to provide services due to the following reasons, they shall not be held responsible for the damage that occurs to users.
+   (1) If there is a natural disaster or other comparable case of force majeure
+   (2) If service is disrupted by a third party that signed a service cooperation agreement with the Company
+   (3) If there is an error in service use due to reasons that are attributable to the user, such as the device environment
+   (4) If the reason is not attributable to the Company's intention or negligence, such as the network environment
+
+Article 10 Agreement Termination
+1) The user may terminate this Agreement at any time by permanently discarding ABLER.
+2) The Company may discontinue its provision of ABLER due to the termination of a partnership or other serious business reasons that render the Company unable to maintain its services.
+3) If the Company discontinues services, the Company shall notify users in accordance with the notification method prescribed in Article 5 Paragraph 3 of these terms at least 3 months before the service termination date.
+However, if the service is not terminated, but merely transferred due to other business operation reasons, the details need not be announced.
+
+Article 11 Compensation for Damages
+1) If the Company suffers damages as a result of the user's violation of these terms, the user who violated these terms must compensate the Company for all resulting damages.
+2) If a user performs illegal activities while using the service or violates these terms, which causes the Company to receive an objection, such as a claim for compensation for damages or lawsuit from a third party aside from the user, the user must indemnify the Company at their expense. If the Company cannot be indemnified, the user must compensate the Company for all damage that occurred.
+3) The Company shall not be held responsible for any damage that occurs regarding a service that is provided for free.
+
+Article 12 Service Dispute Resolution
+1) The Company shall process complaints and opinions that are submitted by the user regarding service use as quickly as possible. However, if it cannot be processed quickly, the Company shall notify the user of the reason and the processing schedule as soon as possible.
+2) Disputes that occur between the Company and user shall follow the mediation process of the e-Commerce Dispute Mediation Committee that is established in accordance with the Framework Act on Electronic Documents and Electronic Commerce.
+3) Any matters that are not stipulated in these terms and interpretations of these terms shall follow the laws of South Korea and commercial practice.
+4) The court of jurisdiction over all disputes and lawsuits related to the service and these terms shall be the Seoul Central District Court or the court of jurisdiction according to the Civil Procedure Law.

--- a/release/darwin/abler.applescript
+++ b/release/darwin/abler.applescript
@@ -7,7 +7,7 @@ tell application "Finder"
         set the bounds of container window to {100, 100, 640, 472}
         set theViewOptions to icon view options of container window
         set arrangement of theViewOptions to not arranged
-        set icon size of theViewOptions to 64
+        set icon size of theViewOptions to 100
         set background picture of theViewOptions to file ".background:background.tif"
         set position of item " " of container window to {400, 190}
         set position of item ".background" of container window to {135, 100}

--- a/release/darwin/abler.applescript
+++ b/release/darwin/abler.applescript
@@ -1,18 +1,21 @@
 tell application "Finder"
-          tell disk "ABLER"
-               open
-               set current view of container window to icon view
-               set toolbar visible of container window to false
-               set statusbar visible of container window to false
-               set the bounds of container window to {100, 100, 640, 472}
-               set theViewOptions to icon view options of container window
-               set arrangement of theViewOptions to not arranged
-               set icon size of theViewOptions to 128
-               set background picture of theViewOptions to file ".background:background.tif"
-               set position of item " " of container window to {400, 190}
-               set position of item "abler.app" of container window to {135, 190}
-               update without registering applications
-               delay 5
-               close
-     end tell
+  tell disk "ABLER"
+    open
+    set current view of container window to icon view
+    set toolbar visible of container window to false
+    set statusbar visible of container window to false
+    set the bounds of container window to {100, 100, 640, 472}
+    set theViewOptions to icon view options of container window
+    set arrangement of theViewOptions to not arranged
+    set icon size of theViewOptions to 128
+    set background picture of theViewOptions to file ".background:background.tif"
+    set position of item " " of container window to {400, 190}
+    set position of item ".background" of container window to {135, 100}
+    set position of item ".fseventsd" of container window to {135, 100}
+    set position of item "README.txt" of container window to {400, 100}
+    set position of item "abler.app" of container window to {135, 190}
+    update without registering applications
+    delay 5
+    close
+  end tell
 end tell

--- a/release/darwin/abler.applescript
+++ b/release/darwin/abler.applescript
@@ -7,7 +7,7 @@ tell application "Finder"
         set the bounds of container window to {100, 100, 640, 472}
         set theViewOptions to icon view options of container window
         set arrangement of theViewOptions to not arranged
-        set icon size of theViewOptions to 128
+        set icon size of theViewOptions to 64
         set background picture of theViewOptions to file ".background:background.tif"
         set position of item " " of container window to {400, 190}
         set position of item ".background" of container window to {135, 100}

--- a/release/darwin/abler.applescript
+++ b/release/darwin/abler.applescript
@@ -1,21 +1,21 @@
 tell application "Finder"
-  tell disk "ABLER"
-    open
-    set current view of container window to icon view
-    set toolbar visible of container window to false
-    set statusbar visible of container window to false
-    set the bounds of container window to {100, 100, 640, 472}
-    set theViewOptions to icon view options of container window
-    set arrangement of theViewOptions to not arranged
-    set icon size of theViewOptions to 128
-    set background picture of theViewOptions to file ".background:background.tif"
-    set position of item " " of container window to {400, 190}
-    set position of item ".background" of container window to {135, 100}
-    set position of item ".fseventsd" of container window to {135, 100}
-    set position of item "README.txt" of container window to {400, 100}
-    set position of item "abler.app" of container window to {135, 190}
-    update without registering applications
-    delay 5
-    close
-  end tell
+    tell disk "ABLER"
+        open
+        set current view of container window to icon view
+        set toolbar visible of container window to false
+        set statusbar visible of container window to false
+        set the bounds of container window to {100, 100, 640, 472}
+        set theViewOptions to icon view options of container window
+        set arrangement of theViewOptions to not arranged
+        set icon size of theViewOptions to 128
+        set background picture of theViewOptions to file ".background:background.tif"
+        set position of item " " of container window to {400, 190}
+        set position of item ".background" of container window to {135, 100}
+        set position of item ".fseventsd" of container window to {135, 100}
+        set position of item "README.txt" of container window to {400, 100}
+        set position of item "abler.app" of container window to {135, 190}
+        update without registering applications
+        delay 5
+        close
+    end tell
 end tell

--- a/release/darwin/abler.applescript
+++ b/release/darwin/abler.applescript
@@ -9,11 +9,11 @@ tell application "Finder"
         set arrangement of theViewOptions to not arranged
         set icon size of theViewOptions to 100
         set background picture of theViewOptions to file ".background:background.tif"
-        set position of item " " of container window to {400, 190}
+        set position of item " " of container window to {400, 206}
         set position of item ".background" of container window to {135, 100}
         set position of item ".fseventsd" of container window to {135, 100}
-        set position of item "README.txt" of container window to {400, 100}
-        set position of item "abler.app" of container window to {135, 190}
+        set position of item "README.txt" of container window to {400, 84}
+        set position of item "abler.app" of container window to {135, 206}
         update without registering applications
         delay 5
         close

--- a/release/darwin/bundle.sh
+++ b/release/darwin/bundle.sh
@@ -213,6 +213,9 @@ if ! test -z "${_background_image}"; then
     cp "${_background_image}" "${_mount_dir}/.background/${_background_image_NAME}"
 fi
 
+echo "Copying README.txt.."
+cp "${_script_dir}/README_EULA.txt" "${_mount_dir}/README.txt"
+
 echo "Creating link to /Applications ..."
 ln -s /Applications "${_mount_dir}/Applications"
 echo "Renaming Applications to empty string."

--- a/release/darwin/bundle.sh
+++ b/release/darwin/bundle.sh
@@ -213,7 +213,7 @@ if ! test -z "${_background_image}"; then
     cp "${_background_image}" "${_mount_dir}/.background/${_background_image_NAME}"
 fi
 
-echo "Copying README.txt.."
+echo "Copying README.txt ..."
 cp "${_script_dir}/README_EULA.txt" "${_mount_dir}/README.txt"
 
 echo "Creating link to /Applications ..."


### PR DESCRIPTION
## 관련 링크
[Jira 티켓 링크](https://carpenstreet.atlassian.net/browse/SWTASK-320)
[유관 Slack 쓰레드](https://acontainer.slack.com/archives/C02K1NPTV42/p1683594124634229)

## 발제/내용
- EULA를 DMG에 넣어서 배포해야함

## 대응

### 어떤 조치를 취했나요?
- 한국어와 영문 EULA가 들어있는 `.txt` 파일을 만들어서 `release/darwin` 폴더에 넣음.
- 해당 파일을 `README.txt`로 DMG 내부에 복사해서 넣는 로직을 `bundle.sh`에 추가함