### PR TITLE
SWTASK-321 에이블러 버전 개선 작업

### DIFF
--- a/release/scripts/startup/abler/lib/version.py
+++ b/release/scripts/startup/abler/lib/version.py
@@ -76,7 +76,7 @@ def get_local_version_macos() -> Optional[str]:
             import plistlib
 
             plist_dict = plistlib.load(fp)
-            version = plist_dict["asdfasdfasfasdfasd"]
+            version = plist_dict["CFBundleVersion"]
     except KeyError:
         return None
 

--- a/release/scripts/startup/abler/lib/version.py
+++ b/release/scripts/startup/abler/lib/version.py
@@ -71,11 +71,14 @@ def find_info_plist() -> Optional[str]:
 
 def get_local_version_macos() -> Optional[str]:
     plist_path = find_info_plist()
-    with open(plist_path, "rb") as fp:
-        import plistlib
+    try:
+        with open(plist_path, "rb") as fp:
+            import plistlib
 
-        plist_dict = plistlib.load(fp)
-        version = plist_dict["CFBundleVersion"]
+            plist_dict = plistlib.load(fp)
+            version = plist_dict["asdfasdfasfasdfasd"]
+    except KeyError:
+        return None
 
     return version
 

--- a/release/scripts/startup/abler/lib/version.py
+++ b/release/scripts/startup/abler/lib/version.py
@@ -85,6 +85,7 @@ def get_local_version() -> str:
             local_ver = get_local_version_macos()
 
         if not local_ver:
+            # TODO: 아래 값 상수화해야할 수 있음
             local_ver = "0.0.0"
 
     return local_ver

--- a/release/scripts/startup/abler/lib/version.py
+++ b/release/scripts/startup/abler/lib/version.py
@@ -7,7 +7,6 @@ import configparser
 import psutil
 from distutils.version import StrictVersion
 from typing import Optional
-from enum import Enum
 
 # GitHub Repo의 URL 세팅
 url = "https://cms.abler3d.biz/abler_update_info"
@@ -46,26 +45,63 @@ def get_launcher_process_count(proc) -> int:
     return proc_count
 
 
-def get_local_version() -> str:
+def get_local_version_windows() -> Optional[str]:
+    version = None
     config = configparser.ConfigParser()
     if os.path.isfile(os.path.join(set_updater(), "config.ini")):
         config.read(os.path.join(set_updater(), "config.ini"))
-        abler_ver = config["main"]["installed"]
-    else:
-        abler_ver = "0.0.0"
+        version = config["main"]["installed"]
 
-    # config.ini에 installed 정보가 없을 때 버전 처리
-    if abler_ver == (None or ""):
-        abler_ver = "0.0.0"
+    return version
 
-    return abler_ver
+
+def find_info_plist() -> Optional[str]:
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    last_dir = None
+    while last_dir != current_dir:
+        check_path = os.path.join(current_dir, "info.plist")
+        if os.path.isfile(check_path):
+            return check_path
+
+        parent_dir = os.path.abspath(os.path.join(current_dir, os.path.pardir))
+        last_dir, current_dir = current_dir, parent_dir
+
+    return check_path
+
+
+def get_local_version_macos() -> Optional[str]:
+    plist_path = find_info_plist()
+    with open(plist_path, "rb") as fp:
+        import plistlib
+
+        plist_dict = plistlib.load(fp)
+        version = plist_dict["CFBundleVersion"]
+
+    return version
+
+
+local_ver = None
+
+
+def get_local_version() -> str:
+    global local_ver
+    if local_ver is None:
+        if sys.platform == "win32":
+            local_ver = get_local_version_windows()
+        elif sys.platform == "darwin":
+            local_ver = get_local_version_macos()
+
+        if not local_ver:
+            local_ver = "0.0.0"
+
+    return local_ver
 
 
 def get_server_version(url) -> Optional[str]:
     # Pre-Release 고려하지 않고 url 정보 받아오기
     req = None
     is_release = None
-    abler_ver = None
+    server_ver = None
 
     try:
         req = requests.get(url, timeout=5).json()
@@ -81,11 +117,11 @@ def get_server_version(url) -> Optional[str]:
             version_tag = filename.split("_")[-1][1:-4]
 
             if "Release" in target:
-                abler_ver = version_tag
+                server_ver = version_tag
     else:
         print("GitHub API URL Error.")
 
-    return abler_ver
+    return server_ver
 
 
 def has_server_update() -> bool:

--- a/release/scripts/startup/abler/lib/version.py
+++ b/release/scripts/startup/abler/lib/version.py
@@ -55,22 +55,11 @@ def get_local_version_windows() -> Optional[str]:
     return version
 
 
-def find_info_plist() -> Optional[str]:
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    last_dir = None
-    while last_dir != current_dir:
-        check_path = os.path.join(current_dir, "info.plist")
-        if os.path.isfile(check_path):
-            return check_path
-
-        parent_dir = os.path.abspath(os.path.join(current_dir, os.path.pardir))
-        last_dir, current_dir = current_dir, parent_dir
-
-    return check_path
-
-
 def get_local_version_macos() -> Optional[str]:
-    plist_path = find_info_plist()
+    # Six Levels Up
+    contents_dir = os.path.dirname(os.path.abspath(os.path.join(__file__, "../../../../../..")))
+    plist_path = os.path.join(contents_dir, "info.plist")
+
     try:
         with open(plist_path, "rb") as fp:
             import plistlib
@@ -83,6 +72,7 @@ def get_local_version_macos() -> Optional[str]:
     return version
 
 
+# Local Version 을 재사용하기 위한 전역 변수
 local_ver = None
 
 


### PR DESCRIPTION
## 관련 링크
[이슈](https://carpenstreet.atlassian.net/browse/SWTASK-321?atlOrigin=eyJpIjoiZjEzMDk4ZDFhYTlkNGM3Njk1ODQ2ZDZhNWNhZDliYzIiLCJwIjoiaiJ9)

## 발제/내용

- macOS 에서 현재 로컬의 에이블러 버전을 가져올 수 없음

- get_local_version 함수 내 로직이 너무 많이 실행됨

## 대응

### 어떤 조치를 취했나요?

- python 모듈 plistlib 을 사용하여 info.plist 의 CFBundleVersion을 가져오게 함

- info.plist 의 위치를 찾는 함수 find_info_list 추가

- get_local_version  함수 각 os 별로 리팩토링

- 처음에만 get_local_version 에서 외부 파일을 읽어오는 로직을 수행해서 global 변수에 버전 정보를 저장하고, 그 후에는 저장한 버전 정보를 사용하도록 변경

- get_local_version, get_server_version 함수의 변수 이름 리팩토링
