### PR TITLE
SWTASK-325 Sparkle Updater 자동 체크 해제하기

### DIFF
--- a/release/darwin/ABLER.app/Contents/Info.plist
+++ b/release/darwin/ABLER.app/Contents/Info.plist
@@ -93,5 +93,9 @@
     <string>${SPARKLE_FEED_ADDRESS}</string>
     <key>SUEnableInstallerLauncherService</key>
     <true/>
+    <key>SUAllowsAutomaticUpdates</key>
+    <false/>
+    <key>SUScheduledCheckInterval</key>
+    <integer>0</integer>
 </dict>
 </plist>


### PR DESCRIPTION
## 관련 링크
[이슈](https://carpenstreet.atlassian.net/browse/SWTASK-313?atlOrigin=eyJpIjoiM2JiNzAxZDE5ZWNjNDg0MWE5MTMzYWJmMWRmNzhmMjgiLCJwIjoiaiJ9)

## 발제/내용

- 에이블러는 원래 앱 가동 시 / 파일 열기 시에만 업데이트 체크를 하고 있기 떄문에 기본 Sparkle Updater 의 자동 업데이트 및 자동 업데이트 체크를 해제한다.

## 대응

### 어떤 조치를 취했나요?

- info.plist 에 `SUAllowsAutomaticUpdates` 값 false 로 추가하여 체크박스 삭제
- info.plist 에 `SUScheduledCheckInterval`  값 0 로 추가하여 자동 체크 해제