### PR TITLE
[SWTASK-326] 복사된 오브젝트를 붙여넣을 때 생성되는 쉐이더에도 Shadow / Shading 옵션 값 적용하기

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -1246,7 +1246,6 @@ def km_view3d(params):
         ("view3d.object_as_camera", {"type": 'NUMPAD_0', "value": 'PRESS', "ctrl": True}, None),
         # Copy/paste.
         ("view3d.copybuffer", {"type": 'C', "value": 'PRESS', "ctrl": True}, None),
-        ("view3d.pastebuffer", {"type": 'V', "value": 'PRESS', "ctrl": True}, None),
         # Transform.
         ("transform.translate", {"type": 'G', "value": 'PRESS'}, None),
         ("transform.translate", {"type": params.select_tweak, "value": 'ANY'}, None),
@@ -4149,7 +4148,7 @@ def km_object_mode(params):
         op_menu("VIEW3D_MT_add", {"type": 'A', "value": 'PRESS', "shift": True}),
         op_menu("VIEW3D_MT_object_apply", {"type": 'A', "value": 'PRESS', "ctrl": True}),
         op_menu("VIEW3D_MT_make_links", {"type": 'L', "value": 'PRESS', "ctrl": True}),
-        ("object.duplicate_move", {"type": 'D', "value": 'PRESS', "shift": True}, None),
+        ("object.duplicate_move", {"type": 'V', "value": 'PRESS', "ctrl": True}, None),
         ("object.duplicate_move_linked", {"type": 'D', "value": 'PRESS', "alt": True}, None),
         ("object.join", {"type": 'J', "value": 'PRESS', "ctrl": True}, None),
         ("wm.context_toggle", {"type": 'PERIOD', "value": 'PRESS', "ctrl": True},

--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -4148,6 +4148,7 @@ def km_object_mode(params):
         op_menu("VIEW3D_MT_add", {"type": 'A', "value": 'PRESS', "shift": True}),
         op_menu("VIEW3D_MT_object_apply", {"type": 'A', "value": 'PRESS', "ctrl": True}),
         op_menu("VIEW3D_MT_make_links", {"type": 'L', "value": 'PRESS', "ctrl": True}),
+        # 관련 작업: https://carpenstreet.atlassian.net/browse/SWTASK-326
         ("object.duplicate_move", {"type": 'V', "value": 'PRESS', "ctrl": True}, None),
         ("object.duplicate_move_linked", {"type": 'D', "value": 'PRESS', "alt": True}, None),
         ("object.join", {"type": 'J', "value": 'PRESS', "ctrl": True}, None),


### PR DESCRIPTION
# [Jira](https://carpenstreet.atlassian.net/browse/SWTASK-326)

에이블러 파일 간에 복사, 붙여넣기를 하면 Shadow & Shading 옵션이 붙여넣기한 파일에서 적용되지 않음.

### 재현 방법

- ~첨부된 파일 chair.blend 를 실행함 (아무 파일이나 상관 없음)~
  - 같은 파일 내에서도 해당 오류 발생함
- 오브젝트 선택 후 복사
- 새 에이블러 실행하고 오브젝트 붙여넣기
- Style > Shadow / Shading 옵션을 껐다 켰다하면 발생함
- 임시 방편으로 에이블러 재실행하고 파일 열면 옵션 적용됨

## 작업 내용

### 원인

- 오브젝트를 복사하면 구성하는 모든 요소가 복제됨. (재질, 텍스처 이미지, 쉐이더 등)
- 이 때, 블렌더에서는 이미 같은 이름의 데이터가 존재하면 이름을 .001 방식으로 넘버링을함.
- 그래서 `ACON_nodeGroup_combinedToon` 노드 그룹이 복제되면서 `.001` 등의 숫자가 붙게되고, 토글은 원본 쉐이더 노드의 값만 바꾸기 때문에 영향이 없음.
- 구성 요소가 복제되는 부분이 문제점인지? 그렇지 않은지? 에 대해서 간단한 고민 스레드
  - [Slack](https://acontainer.slack.com/archives/C02K1NPTV42/p1683801955209529)

### 해결 방안

Duplicate Objects (`Shift` + `D`) 는 오브젝트 뿐만이 아니라 하위의 data-blocks까지 동일하게 복제하는 방식임.
해당 기능을 사용하면, 기존에 오브젝트가 가지고 있는 데이터를 그대로 사용하기 때문에 에이블러의 옵션을 사용하기에는 크게 문제가 없음.

- 관련 문서: [Duplication -- Blender Manual](https://docs.blender.org/manual/en/2.80/scene_layout/object/editing/duplication.html)

### 관련 작업

- `abler_default.py` 에서 `view3d.pastebuffer` 항목 삭제
- `object.duplicate_move` 단축키를 `Shift` + `D` → `Ctrl` + `V` 로 수정

### 결과

![image](https://github.com/carpenstreet/blender/assets/52474700/067d1cbe-4b2d-4beb-8909-70885e0ff53f)

