### PR TITLE
[SWTASK-326] 오브젝트를 복사하고 붙여넣기를 하면 툰 쉐이더가 복제되면서 Style 탭의 옵션이 적용되지 않는 오류

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -1245,8 +1245,9 @@ def km_view3d(params):
         ("view3d.camera_to_view", {"type": 'NUMPAD_0', "value": 'PRESS', "ctrl": True, "alt": True}, None),
         ("view3d.object_as_camera", {"type": 'NUMPAD_0', "value": 'PRESS', "ctrl": True}, None),
         # Copy/paste.
+        # https://carpenstreet.atlassian.net/browse/SWTASK-326
         ("view3d.copybuffer", {"type": 'C', "value": 'PRESS', "ctrl": True}, None),
-        ("view3d.pastebuffer", {"type": 'V', "value": 'PRESS', "ctrl": True}, None),
+        ("acon3d.pastebuffer", {"type": 'V', "value": 'PRESS', "ctrl": True}, None),
         # Transform.
         ("transform.translate", {"type": 'G', "value": 'PRESS'}, None),
         ("transform.translate", {"type": params.select_tweak, "value": 'ANY'}, None),

--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -1245,7 +1245,6 @@ def km_view3d(params):
         ("view3d.camera_to_view", {"type": 'NUMPAD_0', "value": 'PRESS', "ctrl": True, "alt": True}, None),
         ("view3d.object_as_camera", {"type": 'NUMPAD_0', "value": 'PRESS', "ctrl": True}, None),
         # Copy/paste.
-        # https://carpenstreet.atlassian.net/browse/SWTASK-326
         ("view3d.copybuffer", {"type": 'C', "value": 'PRESS', "ctrl": True}, None),
         ("acon3d.pastebuffer", {"type": 'V', "value": 'PRESS', "ctrl": True}, None),
         # Transform.

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -981,7 +981,6 @@ class Acon3dPastebuffer(bpy.types.Operator):
     bl_idname = "acon3d.pastebuffer"
     bl_label = "Paste Objects"
     bl_description = "Objects from the clipboard are pasted"
-    bl_translation_context = "abler"
 
     def execute(self, context):
         bpy.ops.view3d.pastebuffer()

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -975,6 +975,21 @@ class ApplyToonStyleOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class Acon3dPastebuffer(bpy.types.Operator):
+    """Paste Buffer with Apply Toon Style"""
+
+    bl_idname = "acon3d.pastebuffer"
+    bl_label = "Paste Objects"
+    bl_description = "Objects from the clipboard are pasted"
+    bl_translation_context = "abler"
+
+    def execute(self, context):
+        bpy.ops.view3d.pastebuffer()
+        bpy.ops.acon3d.apply_toon_style()
+
+        return {"FINISHED"}
+
+
 classes = (
     OpenAcon3dOperator,
     OpenAcon3dSearchOperator,
@@ -1000,6 +1015,7 @@ classes = (
     ImportSKPOperator,
     ImportSKPModalOperator,
     ImportSKPAcceptOperator,
+    Acon3dPastebuffer,
 )
 
 

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -983,6 +983,9 @@ class Acon3dPastebuffer(bpy.types.Operator):
     bl_description = "Objects from the clipboard are pasted"
 
     def execute(self, context):
+        # 오젝트를 복사하면 구성하는 모든 요소가 (재질, 텍스처 이미지, 쉐이더 등) 복제됨.
+        # 그럼 ACON_nodeGroup_combinedToon.001 등으로 복제되는데, 에이블러 Style 기능이 정상적으로 동작하지 않음.
+        # 그래서 기존의 복사 기능에 에이블러의 툰 스타일 적용 기능을 추가함.
         bpy.ops.view3d.pastebuffer()
         bpy.ops.acon3d.apply_toon_style()
 

--- a/release/scripts/startup/bl_ui/space_view3d.py
+++ b/release/scripts/startup/bl_ui/space_view3d.py
@@ -2575,7 +2575,6 @@ class VIEW3D_MT_object_context_menu(Menu):
                 layout.separator()
 
         # Shared among all object types
-        # https://carpenstreet.atlassian.net/browse/SWTASK-326
         layout.operator("view3d.copybuffer", text="Copy Objects", icon='COPYDOWN')
         layout.operator("acon3d.pastebuffer", text="Paste Objects", icon='PASTEDOWN')
 

--- a/release/scripts/startup/bl_ui/space_view3d.py
+++ b/release/scripts/startup/bl_ui/space_view3d.py
@@ -2575,8 +2575,9 @@ class VIEW3D_MT_object_context_menu(Menu):
                 layout.separator()
 
         # Shared among all object types
+        # https://carpenstreet.atlassian.net/browse/SWTASK-326
         layout.operator("view3d.copybuffer", text="Copy Objects", icon='COPYDOWN')
-        layout.operator("view3d.pastebuffer", text="Paste Objects", icon='PASTEDOWN')
+        layout.operator("acon3d.pastebuffer", text="Paste Objects", icon='PASTEDOWN')
 
         layout.separator()
 


### PR DESCRIPTION
# [Jira](https://carpenstreet.atlassian.net/browse/SWTASK-326)

에이블러 파일 간에 복사, 붙여넣기를 하면 Shadow & Shading 옵션이 붙여넣기한 파일에서 적용되지 않음.

### 재현 방법

- ~첨부된 파일 chair.blend 를 실행함 (아무 파일이나 상관 없음)~
  - 같은 파일 내에서도 해당 오류 발생함
- 오브젝트 선택 후 복사
- 새 에이블러 실행하고 오브젝트 붙여넣기
- Style > Shadow / Shading 옵션을 껐다 켰다하면 발생함
- 임시 방편으로 에이블러 재실행하고 파일 열면 옵션 적용됨

## 작업 내용

### 원인

- 오브젝트를 복사하면 구성하는 모든 요소가 복제됨. (재질, 텍스처 이미지, 쉐이더 등)
- 이 때, 블렌더에서는 이미 같은 이름의 데이터가 존재하면 이름을 .001 방식으로 넘버링을함.
- 그래서 `ACON_nodeGroup_combinedToon` 노드 그룹이 복제되면서 `.001` 등의 숫자가 붙게되고, 토글은 원본 쉐이더 노드의 값만 바꾸기 때문에 영향이 없음.
- 구성 요소가 복제되는 부분이 문제점인지? 그렇지 않은지? 에 대해서 간단한 고민 스레드
  - [Slack](https://acontainer.slack.com/archives/C02K1NPTV42/p1683801955209529)

### 해결 방안

- 블렌더의 붙여넣기는 `bpy.ops.view3d.pastebuffer()` 를 사용함.
- 에이블러의 툰 스타일 적용은 `bpy.ops.acon3d.apply_toon_style()` 을 사용함.
- 이 두 기능을 합친 새로운 bpy 오퍼레이터 생성하기

### 관련 작업

- 오브젝트 붙여넣기와 툰 스타일 적용이 함께되는 오퍼레이터 `class Acon3dPastebuffer` 생성
- 키보드 단축키 및 마우스 우클릭 메뉴 기능 수정
- `view3d.pastebuffer`가 다른 곳에도 사용되지만, 직접적으로 영향을 받는 부분만 교체함
- 번역은 원래 스크립트를 재사용 하기 때문에 따로 추가하지 않음

### 결과

![image](https://github.com/carpenstreet/blender/assets/52474700/067d1cbe-4b2d-4beb-8909-70885e0ff53f)
