### PR TITLE
초기상태에서 언두 수행시 툰쉐이딩까지 해제되는 현상 해결

### DIFF
--- a/source/blender/blenkernel/intern/undo_system.c
+++ b/source/blender/blenkernel/intern/undo_system.c
@@ -344,12 +344,15 @@ static bool undosys_stack_push_main(UndoStack *ustack, const char *name, struct 
   UNDO_NESTED_ASSERT(false);
   BLI_assert(ustack->step_init == NULL);
   CLOG_INFO(&LOG, 1, "'%s'", name);
+
+  /* Toon Shading 작업이 언두되지 않게 하기 위해 original file을 언두스택에 등록하지 않는다.
   bContext *C_temp = CTX_create();
   CTX_data_main_set(C_temp, bmain);
   eUndoPushReturn ret = BKE_undosys_step_push_with_type(
       ustack, C_temp, name, BKE_UNDOSYS_TYPE_MEMFILE);
   CTX_free(C_temp);
-  return (ret & UNDO_PUSH_RET_SUCCESS);
+   */
+  return ((1 << 0) & UNDO_PUSH_RET_SUCCESS);
 }
 
 void BKE_undosys_stack_init_from_main(UndoStack *ustack, struct Main *bmain)


### PR DESCRIPTION
## 발제/내용
언두를 마구마구 수행해서 에이블러 툰쉐이딩까지 해제해버리는 문제 해결

## 블렌더 언두에 대한 필요지식
블렌더 언두는 파이썬이 아닌 C 에서 관리되는 자료구조임 
언두스택에서는 파일전체를 memory에 덤프하고 레퍼런스를 보관하는 식으로 되어있음
따라서 bl_options에 상관없이 모든 오퍼레이션은 언두가 가능함
(bl_options={UNDO}는 단순히 언두스택 체크포인트 추가하는 개념)

## 발생하는 문제 
언두의 가장 처음에는 original file이 올라가 있음
에이블러 실행후 언두를 계속 수행해서 original file로 돌아가면 툰쉐이딩까지 해제가 됨

### 어떤 조치를 취했나요?
 해결하기 위해 초기 언두스택에 원본파일을 올리지 않도록 주석처리함


## 추가사항
언두스택을 변경하는 것이므로 자동저장이라던가, 다른 기능에 영향이 있을 수 있습니다.
기본적인 기능들에 대해선 한번씩 확인해보았지만, 릴리즈 전에 자세한 테스트가 필요합니다.