### PR TITLE
[SWTASK-356] 에이블러 스플래쉬 UX 개선 작업

### DIFF
--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3037,7 +3037,7 @@ def fetch_notices():
         return
     if req is not None and req.status_code == 200:
         ret_list = json.loads(req.text)["results"]
-        notices = ('SUCCESS', ret_list)
+        notices = ('SUCCESS', ret_list[:1])
     else:
         notices = ('FAILED', None)
 
@@ -3134,23 +3134,38 @@ class WM_MT_splash(Menu):
         layout.emboss = 'PULLDOWN_MENU'
 
         split = layout.split()
+        lang = bpy.context.preferences.view.language
 
         col1 = split.column()
-        anchor = col1.operator("acon3d.anchor", text="See ACON3D models!", icon='EVENT_A')
-        anchor.description_text = "Link to ACON3D"
-        anchor.href = 'https://acon3d.com'
-        anchor = col1.operator("acon3d.anchor", text="Don't have an ACON3D account?", icon='USER')
-        anchor.description_text = "Sign up for ACON3D"
-        anchor.href = 'https://www.acon3d.com/member/join'
+        anchor = col1.operator("acon3d.anchor", text="Operating ABLER", icon='URL')
+        anchor.description_text = "Link to Operating ABLER"
+        if lang == "ko_KR":
+            anchor.href = 'https://acon3d.notion.site/27fd2c38710645e09d8bec304eb83505?pvs=4'
+        else:
+            anchor.href = 'https://acon3d.notion.site/Operating-ABLER-9ee94a8169a6400ab9c677dd312e5fdd?pvs=4'
+
+        anchor = col1.operator("acon3d.anchor", text="ABLER Instruction", icon='URL')
+        anchor.description_text = "Link to ABLER Instruction"
+        if lang == "ko_KR":
+            anchor.href = 'https://acon3d.notion.site/6f62d1a599964e10b1ce366e72d7af93?pvs=4'
+        else:
+            anchor.href = 'https://acon3d.notion.site/ABLER-Instructions-c4f25debe71b4fa0adcc7e87f8ccd7a1'
 
         # Blender의 wm.url_open_preset의 툴팁이 고정되어 있어 acon3d.anchor operator로 변경
         col2 = split.column()
-        anchor = col2.operator("acon3d.anchor", text="Blender Release Notes", icon='URL')
-        anchor.description_text = "Link to Blender Foundation and check release notes"
-        anchor.href = 'https://www.blender.org/download/releases/'
-        anchor = col2.operator("acon3d.anchor", text="Blender Development Fund", icon='FUND')
-        anchor.description_text = "Link to Blender development donation program to support maintenance and improvements"
-        anchor.href = 'https://fund.blender.org/'
+        anchor = col2.operator("acon3d.anchor", text="ABLER feature Walkthrough", icon='URL')
+        anchor.description_text = "Link to ABLER feature Walkthrough"
+        if lang == "ko_KR":
+            anchor.href = 'https://acon3d.notion.site/6f62d1a599964e10b1ce366e72d7af93?pvs=4'
+        else:
+            anchor.href = 'https://acon3d.notion.site/ABLER-Feature-Walkthrough-33f7c23e06694137954bb3ea93ca992d?pvs=4'
+
+        anchor = col2.operator("acon3d.anchor", text="See ACON3D models!", icon='URL')
+        anchor.description_text = "Link to ACON3D"
+        if lang == "ko_KR":
+            anchor.href = 'https://www.acon3d.com/ko/toon'
+        else:
+            anchor.href = 'https://www.acon3d.com/en/toon'
 
         # 공지사항 파트
         fetch_notices()

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import os
 import sys
 import json
+from enum import Enum
+
 import requests
 
 import bpy
@@ -85,36 +87,43 @@ rna_module_prop = StringProperty(
     maxlen=1024,
 )
 
-class URLs_base:
-    abler_main = "https://acon3d.notion.site/ABLER-User-Guide-316838433d0141ffa4dd11dccc80982c"
-    operating_abler = "https://acon3d.notion.site/Operating-ABLER-9ee94a8169a6400ab9c677dd312e5fdd?pvs=4"
-    abler_features = "https://acon3d.notion.site/ABLER-Feature-Walkthrough-33f7c23e06694137954bb3ea93ca992d"
-    abler_instruction = "https://acon3d.notion.site/ABLER-Instructions-c4f25debe71b4fa0adcc7e87f8ccd7a1"
-    acon_3d = "https://www.acon3d.com/en/toon"
+class URLs_Base(Enum):
 
-class URLs_En(URLs_base):
-    pass
+    @classmethod
+    def get_url(cls, url_name):
+        if url_name in cls.__members__:
+            return cls[url_name].value
 
-class URLs_Ko(URLs_base):
-    abler_main = "https://acon3d.notion.site/ae6c0a608fd749b4a14b1cf98f058ff7"
-    operating_abler = "https://acon3d.notion.site/27fd2c38710645e09d8bec304eb83505"
-    abler_features = "https://acon3d.notion.site/6f62d1a599964e10b1ce366e72d7af93"
-    abler_instruction = "https://acon3d.notion.site/79775e5c0334407ab994764dafbddfc5"
-    acon_3d = "https://www.acon3d.com/ko/toon"
+        # 만약 일부 field가 없다면 En으로대체
+        return URLs_En[url_name].value
 
-class URLs_Ja(URLs_base):
-    abler_main = "https://acon3d.notion.site/ABLER-bc26a6b09de14dfba8f9f10cebb87df2"
-    operating_abler = "https://acon3d.notion.site/ABLER-_-e3df150bbb804273a80504d989a012e3"
-    abler_features = "https://acon3d.notion.site/ABLER-_-45d5fab2b2d54d36a2b73dd2eb13146d"
-    alber_instruction = "https://acon3d.notion.site/ABLER-_-f24764a83e39441badff6d1126cf9b30"
-    acon_3d = "https://www.acon3d.com/ja/toon"
+class URLs_En(URLs_Base):
+    ABLER_MAIN = "https://acon3d.notion.site/ABLER-User-Guide-316838433d0141ffa4dd11dccc80982c"
+    OPERATING_ABLER = "https://acon3d.notion.site/Operating-ABLER-9ee94a8169a6400ab9c677dd312e5fdd?pvs=4"
+    ABLER_FEATURES = "https://acon3d.notion.site/ABLER-Feature-Walkthrough-33f7c23e06694137954bb3ea93ca992d"
+    ABLER_INSTRUCTION = "https://acon3d.notion.site/ABLER-Instructions-c4f25debe71b4fa0adcc7e87f8ccd7a1"
+    ACON_3D = "https://www.acon3d.com/en/toon"
 
-class URLs_Zh(URLs_base):
-    abler_main = "https://acon3d.notion.site/ABLER-1433d7c4cbb1496a883f9dee6b41fb68"
-    operating_abler = "https://acon3d.notion.site/2-ABLER-ac5b3051aead477aa828dadccd73bfdf"
-    abler_features = "https://acon3d.notion.site/3-ABLER-5f8ef0a19d4c4921b02d6f7e6b1b7482"
-    abler_instruction = "https://acon3d.notion.site/4-ABLER-3af1026041ee4147b120e760bef1f301"
-    acon_3d = "https://www.acon3d.com/zh/toon"
+class URLs_Ko(URLs_Base):
+    ABLER_MAIN = "https://acon3d.notion.site/ae6c0a608fd749b4a14b1cf98f058ff7"
+    OPERATING_ABLER = "https://acon3d.notion.site/27fd2c38710645e09d8bec304eb83505"
+    ABLER_FEATURES = "https://acon3d.notion.site/6f62d1a599964e10b1ce366e72d7af93"
+    ABLER_INSTRUCTION = "https://acon3d.notion.site/79775e5c0334407ab994764dafbddfc5"
+    ACON_3D = "https://www.acon3d.com/ko/toon"
+
+class URLs_Ja(URLs_Base):
+    ABLER_MAIN = "https://acon3d.notion.site/ABLER-bc26a6b09de14dfba8f9f10cebb87df2"
+    OPERATING_ABLER = "https://acon3d.notion.site/ABLER-_-e3df150bbb804273a80504d989a012e3"
+    ABLER_FEATURES = "https://acon3d.notion.site/ABLER-_-45d5fab2b2d54d36a2b73dd2eb13146d"
+    ABLER_INSTRUCTION = "https://acon3d.notion.site/ABLER-_-f24764a83e39441badff6d1126cf9b30"
+    ACON_3D = "https://www.acon3d.com/ja/toon"
+
+class URLs_Zh(URLs_Base):
+    ABLER_MAIN = "https://acon3d.notion.site/ABLER-1433d7c4cbb1496a883f9dee6b41fb68"
+    OPERATING_ABLER = "https://acon3d.notion.site/2-ABLER-ac5b3051aead477aa828dadccd73bfdf"
+    ABLER_FEATURES = "https://acon3d.notion.site/3-ABLER-5f8ef0a19d4c4921b02d6f7e6b1b7482"
+    ABLER_INSTRUCTION = "https://acon3d.notion.site/4-ABLER-3af1026041ee4147b120e760bef1f301"
+    ACON_3D = "https://www.acon3d.com/zh/toon"
 
 lang_url_dicts = {
     "ko_KR": URLs_Ko,
@@ -3198,21 +3207,21 @@ class WM_MT_splash(Menu):
         col1 = split.column()
         anchor = col1.operator("acon3d.anchor", text="Operating ABLER", icon='URL')
         anchor.description_text = "Link to Operating ABLER"
-        anchor.href = urls.operating_abler
+        anchor.href = urls.get_url("OPERATING_ABLER")
 
         anchor = col1.operator("acon3d.anchor", text="ABLER Instruction", icon='URL')
         anchor.description_text = "Link to ABLER Instruction"
-        anchor.href = urls.abler_instruction
+        anchor.href = urls.get_url("ABLER_INSTRUCTION")
 
         # Blender의 wm.url_open_preset의 툴팁이 고정되어 있어 acon3d.anchor operator로 변경
         col2 = split.column()
         anchor = col2.operator("acon3d.anchor", text="ABLER feature Walkthrough", icon='URL')
         anchor.description_text = "Link to ABLER feature Walkthrough"
-        anchor.href = urls.abler_features
+        anchor.href = urls.get_url("ABLER_FEATURES")
 
         anchor = col2.operator("acon3d.anchor", text="See ACON3D models!", icon='URL')
         anchor.description_text = "Link to ACON3D"
-        anchor.href = urls.acon_3d
+        anchor.href = urls.get_url("ACON_3D")
 
         # 공지사항 파트
         global lang_notice_dict
@@ -3333,7 +3342,7 @@ class WM_MT_splash_tutorial(Menu):
         cur_lang = bpy.context.preferences.view.language
 
         global lang_url_dicts
-        anchor.url = lang_url_dicts.get(cur_lang, URLs_En).abler_main
+        anchor.url = lang_url_dicts.get(cur_lang, URLs_En).get_url("ABLER_MAIN")
 
         layout.separator()
 

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3021,13 +3021,17 @@ class WM_MT_splash_quick_setup(Menu):
         layout.separator()
 
 # 성공하면 ('SUCCESS', [...]) 실패하면 ('FAILED', None) 이 채워짐
-lang_notice_map = {}
+lang_notice_dict = {}
 
-def fetch_notices(lang: str):
+def fetch_notices(lang: str = None):
+
+    if not lang or lang not in bpy.app.translations.locales:
+        return
+
     # 전에 이미 성공/실패했으면 일찍 종료
-    global lang_notice_map
+    global lang_notice_dict
 
-    if lang in lang_notice_map.keys():
+    if lang in lang_notice_dict.keys():
         return
 
     req = None
@@ -3049,7 +3053,7 @@ def fetch_notices(lang: str):
             result.append(item)
             if len(result) >= 3:
                 break
-        lang_notice_map[lang] = result
+        lang_notice_dict[lang] = result
 
 class WM_MT_splash(Menu):
     bl_label = "Splash"
@@ -3183,22 +3187,22 @@ class WM_MT_splash(Menu):
             anchor.href = 'https://www.acon3d.com/en/toon'
 
         # 공지사항 파트
-        global lang_notice_map
+        global lang_notice_dict
         fetch_notices(lang)
-        if lang in lang_notice_map.keys():
-            notice = lang_notice_map[lang]
+        if lang in lang_notice_dict.keys():
+            notice = lang_notice_dict[lang]
             layout.separator()
             layout.label(text="Notice:", text_ctxt="*")
             for item in notice:
-                but = layout.operator("acon3d.notice", text=item["title"], icon='URL')
-                but.title = item["title"]
-                but.content = item["content"]
+                btn = layout.operator("acon3d.notice", text=item["title"], icon='URL')
+                btn.title = item["title"]
+                btn.content = item["content"]
                 if item["link"] is not None:
-                    but.link = item["link"]["url"]
-                    but.link_name = item["link"]["title"]
+                    btn.link = item["link"]["url"]
+                    btn.link_name = item["link"]["title"]
                 else:
-                    but.link = ""
-                    but.link_name = ""
+                    btn.link = ""
+                    btn.link_name = ""
 
         # blender 관련
         anchor = layout.operator("acon3d.anchor", text="Blender Release Notes", icon='URL')

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3022,13 +3022,20 @@ class WM_MT_splash_quick_setup(Menu):
 
 # 성공하면 ('SUCCESS', [...]) 실패하면 ('FAILED', None) 이 채워짐
 notices = ('READY', None)
+prev_lang = None
 
 def fetch_notices():
     # 전에 이미 성공/실패했으면 일찍 종료
     global notices
-    if notices[0] != 'READY':
-        return
+    global prev_lang
+
     lang = bpy.context.preferences.view.language.split('_')[0]
+
+    if notices[0] != 'READY' and prev_lang == lang:
+        return
+
+    prev_lang = lang
+
     req = None
     try:
         req = requests.get(f"https://cms.abler3d.biz/notices/?language={lang}", timeout=5)

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -85,6 +85,43 @@ rna_module_prop = StringProperty(
     maxlen=1024,
 )
 
+class URLs_base:
+    abler_main = "https://acon3d.notion.site/ABLER-User-Guide-316838433d0141ffa4dd11dccc80982c"
+    operating_abler = "https://acon3d.notion.site/Operating-ABLER-9ee94a8169a6400ab9c677dd312e5fdd?pvs=4"
+    abler_features = "https://acon3d.notion.site/ABLER-Feature-Walkthrough-33f7c23e06694137954bb3ea93ca992d"
+    abler_instruction = "https://acon3d.notion.site/ABLER-Instructions-c4f25debe71b4fa0adcc7e87f8ccd7a1"
+    acon_3d = "https://www.acon3d.com/en/toon"
+
+class URLs_En(URLs_base):
+    pass
+
+class URLs_Ko(URLs_base):
+    abler_main = "https://acon3d.notion.site/ae6c0a608fd749b4a14b1cf98f058ff7"
+    operating_abler = "https://acon3d.notion.site/27fd2c38710645e09d8bec304eb83505"
+    abler_features = "https://acon3d.notion.site/6f62d1a599964e10b1ce366e72d7af93"
+    abler_instruction = "https://acon3d.notion.site/79775e5c0334407ab994764dafbddfc5"
+    acon_3d = "https://www.acon3d.com/ko/toon"
+
+class URLs_Ja(URLs_base):
+    abler_main = "https://acon3d.notion.site/ABLER-bc26a6b09de14dfba8f9f10cebb87df2"
+    operating_abler = "https://acon3d.notion.site/ABLER-_-e3df150bbb804273a80504d989a012e3"
+    abler_features = "https://acon3d.notion.site/ABLER-_-45d5fab2b2d54d36a2b73dd2eb13146d"
+    alber_instruction = "https://acon3d.notion.site/ABLER-_-f24764a83e39441badff6d1126cf9b30"
+    acon_3d = "https://www.acon3d.com/ja/toon"
+
+class URLs_Zh(URLs_base):
+    abler_main = "https://acon3d.notion.site/ABLER-1433d7c4cbb1496a883f9dee6b41fb68"
+    operating_abler = "https://acon3d.notion.site/2-ABLER-ac5b3051aead477aa828dadccd73bfdf"
+    abler_features = "https://acon3d.notion.site/3-ABLER-5f8ef0a19d4c4921b02d6f7e6b1b7482"
+    abler_instruction = "https://acon3d.notion.site/4-ABLER-3af1026041ee4147b120e760bef1f301"
+    acon_3d = "https://www.acon3d.com/zh/toon"
+
+lang_url_dicts = {
+    "ko_KR": URLs_Ko,
+    "en_US": URLs_En,
+    "ja_JP": URLs_Ja,
+    "zh_CN": URLs_Zh,
+}
 
 def context_path_validate(context, data_path):
     try:
@@ -3043,9 +3080,10 @@ def fetch_notices(lang: str = None):
         release_appeared = False
         result = []
         for item in json.loads(req.text)["results"]:
+            # 버전 릴리즈 notice는 가장 최신만 보여준다.
             if item["title"].count('.') >= 2:
                 # 릴리즈 노트 아이템 이미 추가
-                if release_appeared == True:
+                if release_appeared:
                     continue
                 result.append(item)
                 release_appeared = True
@@ -3054,6 +3092,7 @@ def fetch_notices(lang: str = None):
             if len(result) >= 3:
                 break
         lang_notice_dict[lang] = result
+
 
 class WM_MT_splash(Menu):
     bl_label = "Splash"
@@ -3154,37 +3193,26 @@ class WM_MT_splash(Menu):
         layout.emboss = 'PULLDOWN_MENU'
 
         split = layout.split()
+        urls = lang_url_dicts.get(lang, URLs_En)
 
         col1 = split.column()
         anchor = col1.operator("acon3d.anchor", text="Operating ABLER", icon='URL')
         anchor.description_text = "Link to Operating ABLER"
-        if lang == "ko_KR":
-            anchor.href = 'https://acon3d.notion.site/27fd2c38710645e09d8bec304eb83505?pvs=4'
-        else:
-            anchor.href = 'https://acon3d.notion.site/Operating-ABLER-9ee94a8169a6400ab9c677dd312e5fdd?pvs=4'
+        anchor.href = urls.operating_abler
 
         anchor = col1.operator("acon3d.anchor", text="ABLER Instruction", icon='URL')
         anchor.description_text = "Link to ABLER Instruction"
-        if lang == "ko_KR":
-            anchor.href = 'https://acon3d.notion.site/6f62d1a599964e10b1ce366e72d7af93?pvs=4'
-        else:
-            anchor.href = 'https://acon3d.notion.site/ABLER-Instructions-c4f25debe71b4fa0adcc7e87f8ccd7a1'
+        anchor.href = urls.abler_instruction
 
         # Blender의 wm.url_open_preset의 툴팁이 고정되어 있어 acon3d.anchor operator로 변경
         col2 = split.column()
         anchor = col2.operator("acon3d.anchor", text="ABLER feature Walkthrough", icon='URL')
         anchor.description_text = "Link to ABLER feature Walkthrough"
-        if lang == "ko_KR":
-            anchor.href = 'https://acon3d.notion.site/6f62d1a599964e10b1ce366e72d7af93?pvs=4'
-        else:
-            anchor.href = 'https://acon3d.notion.site/ABLER-Feature-Walkthrough-33f7c23e06694137954bb3ea93ca992d?pvs=4'
+        anchor.href = urls.abler_features
 
         anchor = col2.operator("acon3d.anchor", text="See ACON3D models!", icon='URL')
         anchor.description_text = "Link to ACON3D"
-        if lang == "ko_KR":
-            anchor.href = 'https://www.acon3d.com/ko/toon'
-        else:
-            anchor.href = 'https://www.acon3d.com/en/toon'
+        anchor.href = urls.acon_3d
 
         # 공지사항 파트
         global lang_notice_dict
@@ -3280,7 +3308,6 @@ class WM_MT_splash_about(Menu):
         col.emboss = 'PULLDOWN_MENU'
         col.operator("wm.url_open", text="License", icon='URL').url = "https://www.blender.org/about/license/"
 
-
 class WM_MT_splash_tutorial(Menu):
     bl_label = "Tutorial"
 
@@ -3304,14 +3331,10 @@ class WM_MT_splash_tutorial(Menu):
         # general.py에 언어 설정 코드가 있긴 하지만 __init__.py가 달라 재활용할 수 없음
         # 따라서 여기서 언어 설정 코드를 따로 지정
         cur_lang = bpy.context.preferences.view.language
-        if cur_lang == "ko_KR":
-            anchor.url = 'https://acon3d.notion.site/ae6c0a608fd749b4a14b1cf98f058ff7'
-        elif cur_lang == "ja_JP":
-            anchor.url = 'https://acon3d.notion.site/ABLER-bc26a6b09de14dfba8f9f10cebb87df2'
-        elif cur_lang == "zh_CN" or cur_lang == "zh_TW":
-            anchor.url = 'https://acon3d.notion.site/ABLER-1433d7c4cbb1496a883f9dee6b41fb68'
-        else: # en_US + 지원되지 않는 언어는 영어로
-            anchor.url = 'https://acon3d.notion.site/ABLER-User-Guide-316838433d0141ffa4dd11dccc80982c'  
+
+        global lang_url_dicts
+        anchor.url = lang_url_dicts.get(cur_lang, URLs_En).abler_main
+
         layout.separator()
 
         row = layout.row()


### PR DESCRIPTION
## 발제/내용
스플래쉬 창의  회원가입, 사용법 안내, 공지사항 등의 UX를 강화하기 위한 작업


### 어떤 조치를 취했나요?
1. 언어를 변경해도 적용안되던 공지사항, 해쉬맵(언어->내용) 으로 관리하도록 수정해서 개선
2. 회원가입 버튼의 위치 로그인창 아래로 옮겨서 UX 개선
3. 중요도에 맞게 공지사항 리스트 위치 수정


### 수정내용은 아래의 사진 참고
before
<img width="539" alt="스크린샷 2023-06-08 오후 2 55 14" src="https://github.com/carpenstreet/blender/assets/130434011/9c653367-b696-40c1-a101-6512399f598b">
after
<img width="536" alt="스크린샷 2023-06-08 오후 2 54 34" src="https://github.com/carpenstreet/blender/assets/130434011/99cf7736-235a-4c52-9f88-171277452879">
