### PR TITLE
[SWTASK-331] 현재는 사용하지 않는 재질의 포맷을 사용하는 오류

### DIFF
--- a/release/scripts/startup/abler/lib/materials/materials_setup.py
+++ b/release/scripts/startup/abler/lib/materials/materials_setup.py
@@ -567,6 +567,23 @@ def apply_ACON_toon_style():
             if not is_node_texImage and not is_out_node and not is_node_combinedToon:
                 mat.node_tree.nodes.remove(node)
 
+        if "ACON_mat_mirror" in mat.name:
+            mat.ACON_prop.type = "Mirror"
+
+        if "ACON_mat_light" in mat.name:
+            mat.ACON_prop.type = "Glow"
+
+            strength = 1
+
+            try:
+                components = mat.name.split("_")
+                strength = 1.6 ** (int(components[3]) - 3.2)
+            except:
+                print("Following ACON_mat has invalid format")
+                print(mat.name)
+
+            node_combinedToon.inputs[5].default_value = strength
+
         if "ACON_mat_clear" in mat.name:
             mat.ACON_prop.type = "Clear"
 

--- a/release/scripts/startup/abler/lib/materials/materials_setup.py
+++ b/release/scripts/startup/abler/lib/materials/materials_setup.py
@@ -567,26 +567,8 @@ def apply_ACON_toon_style():
             if not is_node_texImage and not is_out_node and not is_node_combinedToon:
                 mat.node_tree.nodes.remove(node)
 
-        if "ACON_mat" in mat.name:
-            if "mirror" in mat.name:
-                mat.ACON_prop.type = "Mirror"
-
-            if "light" in mat.name:
-                mat.ACON_prop.type = "Glow"
-
-                strength = 1
-
-                try:
-                    components = mat.name.split("_")
-                    strength = 1.6 ** (int(components[3]) - 3.2)
-                except:
-                    print("Fllowing ACON_mat has invalid format")
-                    print(mat.name)
-
-                node_combinedToon.inputs[5].default_value = strength
-
-            if "clear" in mat.name:
-                mat.ACON_prop.type = "Clear"
+        if "ACON_mat_clear" in mat.name:
+            mat.ACON_prop.type = "Clear"
 
         materials_handler.set_material_parameters_by_type(mat)
         override = SimpleNamespace()


### PR DESCRIPTION
# [Jira](https://carpenstreet.atlassian.net/browse/SWTASK-331)

에러 자체는 OS 상관 없이 모두 발생

- 에러 로그

  ```python
  Read prefs: C:\Users\habi\AppData\Roaming\Blender Foundation\Blender\2.96\config\userpref.blend
  ...생략...
  SU | Collection minimized in 10.2803 sec.
  Fllowing ACON_mat has invalid format
  ACON_mat_clear MI_light_tr_1
  SU | Toon-style applied in 10.5104 sec.
  SU | Finished importing in 10.5104 sec.
  Saved session recovery to 'C:\Users\habi\AppData\Local\Temp\quit.blend'
  ```

## 작업 내용

- 재질이 투명 타입이면 `ACON_mat_clear` 가 재질 이름 앞에 붙는데, 스케치업 재질 중 `light` 라는 문자열이 포함된 투명 재질을 가져오면서 전혀 관련 없는 요소를 변형하려는 부분이 문제였음.
- 에이블러 초기 작업 (ABLER 저장소) 코드이며, clear 재질은 따로 처리되고 mirror와 light는 사용되지 않음.
- 해당 코드는 아래 commit > `materials.py`에서 찾을 수 있으며, 불필요한 부분이라 판단하고 삭제함.
  - https://github.com/carpenstreet/ABLER/commit/545181d69f1b4251a660c073bb62154cebf7601a