### PR TITLE
[SWTASK-132] 레이어 추가 기능

### DIFF
--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -57,6 +57,7 @@ class EventKind(enum.Enum):
     tutorial_guide_on = "Quick Start Guide On"
     open_acon3d = "Open Acon3d"
     open_search_acon3d = "Search on Acon3d"
+    create_layer = "Create Layer"
 
 
 def accumulate(interval=0):
@@ -310,6 +311,9 @@ class Tracker(metaclass=ABCMeta):
 
     def open_search_acon3d(self, data):
         self._track(EventKind.open_search_acon3d.value, data)
+
+    def create_layer(self):
+        self._track(EventKind.create_layer.value)
 
 
 class DummyTracker(Tracker):

--- a/release/scripts/startup/abler/scene_tab/layer_control.py
+++ b/release/scripts/startup/abler/scene_tab/layer_control.py
@@ -207,6 +207,17 @@ class Acon3dCreateCollection(bpy.types.Operator):
 
     def execute(self, context):
         bpy.ops.object.link_to_collection(collection_index=1, is_new=True)
+
+        # Collection 목록을 Scene > Layers에 업데이트 하기
+        # https://www.notion.so/acon3d/to-127d21725cc641b1a28d6451d3949bb1?pvs=4
+        scene = context.scene
+        for _ in range(len(scene.l_exclude)):
+            scene.l_exclude.remove(0)
+
+        for l in bpy.data.collections["Layers"].children:
+            l_exclude = scene.l_exclude.add()
+            l_exclude.name = l.name
+
         return {"FINISHED"}
 
 

--- a/release/scripts/startup/abler/scene_tab/layer_control.py
+++ b/release/scripts/startup/abler/scene_tab/layer_control.py
@@ -189,17 +189,29 @@ class Acon3dLayersPanel(bpy.types.Panel):
 
             # Layer 생성 버튼
             col = row.column()
-            col.operator("object.link_to_collection", text="", icon="ADD")
+            col.operator("acon3d.create_collection", text="", icon="ADD")
         else:
             layout = self.layout
             row = layout.row(align=True)
             row.label(text="No 'Layers' collection in Outliner")
 
 
+class Acon3dCreateCollection(bpy.types.Operator):
+    bl_idname = "acon3d.create_collection"
+    bl_label = "Create Collection"
+    bl_description = "Create a new collection and link objects to a collection"
+
+    # TODO: 오브젝트가 선택되지 않으면 버튼 비활성 하기
+    def execute(self, context):
+        bpy.ops.object.link_to_collection(collection_index=1, is_new=True)
+        return {"FINISHED"}
+
+
 classes = (
     Acon3dCreateGroupOperator,
     Acon3dExplodeGroupOperator,
     Acon3dLayersPanel,
+    Acon3dCreateCollection,
 )
 
 

--- a/release/scripts/startup/abler/scene_tab/layer_control.py
+++ b/release/scripts/startup/abler/scene_tab/layer_control.py
@@ -189,20 +189,20 @@ class Acon3dLayersPanel(bpy.types.Panel):
 
             # Layer 생성 버튼
             col = row.column()
-            col.operator("acon3d.create_collection", text="", icon="ADD")
+            col.operator("acon3d.create_layer", text="", icon="ADD")
         else:
             layout = self.layout
             row = layout.row(align=True)
             row.label(text="No 'Layers' collection in Outliner")
 
 
-class Acon3dCreateCollection(bpy.types.Operator):
-    bl_idname = "acon3d.create_collection"
-    bl_label = "Create Collection"
-    bl_description = "Create a new collection and link objects to a collection"
+class Acon3dCreateLayer(bpy.types.Operator):
+    bl_idname = "acon3d.create_layer"
+    bl_label = "Create Layer"
+    bl_description = "Create a new layer and link objects to a layer"
 
     name: bpy.props.StringProperty(
-        name="Name", default="Collection", description="Write collection name"
+        name="Name", default="ACON_Layer", description="Write layer name"
     )
 
     @classmethod
@@ -234,7 +234,7 @@ classes = (
     Acon3dCreateGroupOperator,
     Acon3dExplodeGroupOperator,
     Acon3dLayersPanel,
-    Acon3dCreateCollection,
+    Acon3dCreateLayer,
 )
 
 

--- a/release/scripts/startup/abler/scene_tab/layer_control.py
+++ b/release/scripts/startup/abler/scene_tab/layer_control.py
@@ -201,7 +201,10 @@ class Acon3dCreateCollection(bpy.types.Operator):
     bl_label = "Create Collection"
     bl_description = "Create a new collection and link objects to a collection"
 
-    # TODO: 오브젝트가 선택되지 않으면 버튼 비활성 하기
+    @classmethod
+    def poll(cls, context):
+        return len(context.selected_objects) > 0
+
     def execute(self, context):
         bpy.ops.object.link_to_collection(collection_index=1, is_new=True)
         return {"FINISHED"}

--- a/release/scripts/startup/abler/scene_tab/layer_control.py
+++ b/release/scripts/startup/abler/scene_tab/layer_control.py
@@ -205,6 +205,9 @@ class Acon3dCreateCollection(bpy.types.Operator):
     def poll(cls, context):
         return len(context.selected_objects) > 0
 
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
+
     def execute(self, context):
         bpy.ops.object.link_to_collection(collection_index=1, is_new=True)
 

--- a/release/scripts/startup/abler/scene_tab/layer_control.py
+++ b/release/scripts/startup/abler/scene_tab/layer_control.py
@@ -33,6 +33,7 @@ bl_info = {
 
 import bpy
 from ..lib import layers
+from ..lib.tracker import tracker
 
 
 class Acon3dCreateGroupOperator(bpy.types.Operator):
@@ -218,6 +219,7 @@ class Acon3dCreateLayer(bpy.types.Operator):
         # bpy.ops.object.link_to_collection(collection_index=...)을 사용하기가 힘듬.
         # 그래서 "Layers" 하위에 컬렉션을 직접 생성하고, 여기에 선택된 오브젝트를 link 하는 방식을 사용함.
         # https://devtalk.blender.org/t/where-to-find-collection-index-for-moving-an-object/3289/5
+        tracker.create_layer()
 
         # 새로운 collection을 생성하고 "Layers" 하위로 link
         layers = bpy.data.collections["Layers"]

--- a/release/scripts/startup/abler/scene_tab/layer_control.py
+++ b/release/scripts/startup/abler/scene_tab/layer_control.py
@@ -201,6 +201,10 @@ class Acon3dCreateCollection(bpy.types.Operator):
     bl_label = "Create Collection"
     bl_description = "Create a new collection and link objects to a collection"
 
+    name: bpy.props.StringProperty(
+        name="Name", default="Collection", description="Write collection name"
+    )
+
     @classmethod
     def poll(cls, context):
         return len(context.selected_objects) > 0
@@ -209,7 +213,9 @@ class Acon3dCreateCollection(bpy.types.Operator):
         return context.window_manager.invoke_props_dialog(self)
 
     def execute(self, context):
-        bpy.ops.object.link_to_collection(collection_index=1, is_new=True)
+        bpy.ops.object.link_to_collection(
+            collection_index=1, is_new=True, new_collection_name=self.name
+        )
 
         # Collection 목록을 Scene > Layers에 업데이트 하기
         # https://www.notion.so/acon3d/to-127d21725cc641b1a28d6451d3949bb1?pvs=4

--- a/release/scripts/startup/abler/scene_tab/layer_control.py
+++ b/release/scripts/startup/abler/scene_tab/layer_control.py
@@ -175,8 +175,10 @@ class Acon3dLayersPanel(bpy.types.Panel):
         if "Layers" in view_layer.layer_collection.children:
             layout = self.layout
             layout.use_property_split = False
-            box = layout.box()
+            row = layout.row()
 
+            # Layers list
+            box = row.column().box()
             self._draw_collection(
                 box,
                 view_layer,
@@ -184,6 +186,10 @@ class Acon3dLayersPanel(bpy.types.Panel):
                 view_layer.layer_collection.children["Layers"],
                 1,
             )
+
+            # Layer 생성 버튼
+            col = row.column()
+            col.operator("object.link_to_collection", text="", icon="ADD")
         else:
             layout = self.layout
             row = layout.row(align=True)

--- a/release/scripts/startup/abler/scene_tab/layer_control.py
+++ b/release/scripts/startup/abler/scene_tab/layer_control.py
@@ -200,9 +200,10 @@ class Acon3dCreateLayer(bpy.types.Operator):
     bl_idname = "acon3d.create_layer"
     bl_label = "Create Layer"
     bl_description = "Create a new layer and link objects to a layer"
+    bl_translation_context = "abler"
 
     name: bpy.props.StringProperty(
-        name="Name", default="ACON_Layer", description="Write layer name"
+        name="Layer Name", default="ACON_Layer", description="Write layer name"
     )
 
     @classmethod


### PR DESCRIPTION
# [Jira](https://carpenstreet.atlassian.net/browse/SWTASK-132)

n개의 오브젝트를 선택한 뒤에 특정 단축키 또는 특정 버튼 (또는 컨텍스트 메뉴에 있는 버튼)을 누르면 해당 오브젝트들이 하나의 레이어로 묶여서 하나의 레이어가 추가될 수 있도록 하는 기능

- 생성할 때 팝업
- 레이어 이름 생성

### 관련 작업

- https://github.com/carpenstreet/blender-translations/pull/56

## 작업 내용

- Scene 탭의 Layers 패널에 레이어 생성 버튼 추가
  - Collection을 생성하면서 선택된 오브젝트를 collection에 연결
  - 오브젝트가 선택되지 않으면 비활성 하기
- Collection을 추가하면 Layers 목록에 새 collection 업데이트 하기
  - [Notion: 블렌더 to 에이블러 수동 편집](https://www.notion.so/acon3d/to-127d21725cc641b1a28d6451d3949bb1?pvs=4)
  - 위 문서의 레이어 생성 방법 참고
- 레이어 이름 입력을 위해서 실행 시 dialog를 발생하도록 변경
- Collection index 탐색을 이름 연결 방식으로 변경
  - Blender의 컬렉션 데이터는 이름순으로 정렬되기 때문에 `collection_index` 값이 달라짐
  - 컬렉션을 이름 기반으로 생성하고 오브젝트를 직접 연결하는 방식을 사용
  - [Where to find collection_index for moving an object?](https://devtalk.blender.org/t/where-to-find-collection-index-for-moving-an-object/3289)
  - `bpy.ops.object.link_to_collection()` 대신 `bpy.data.collections.new()` 로 새 컬렉션을 생성하고 link 기능을 통해서 연결함
    - 새 컬렉션 → 뷰 레이어 > Layers
    - 선택된 오브젝트 → 새 컬렉션
- 번역 작업
  - 링크

### 결과

![image](https://github.com/carpenstreet/blender/assets/52474700/3780563d-7e86-4d21-9834-cbef34aa469e)
