### PR TITLE
SWTASK-359 에이블러 렌더 이미지 저장 정책을 폴더링 방식에서 파일명 방식으로 변경

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -75,6 +75,9 @@ class AconWindowManagerProperty(bpy.types.PropertyGroup):
         update=scenes.load_scene_by_index, name="Scene"
     )
 
+    render_default_path: bpy.props.StringProperty(
+        name="Render Default Path", description="Default Directory Path for Render"
+    )
     hq_render_full: bpy.props.BoolProperty(
         name="Full Render",
         description="Render according to the set pixel",

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -97,6 +97,10 @@ def delayed_load_handler():
         scenes.refresh_look_at_me()
         scenes.snap_to_face()
         scenes.add_scene_items_to_collection()
+
+        # Render Init
+        bpy.context.window_manager.ACON_prop.render_default_path = ""
+
         post_open.change_and_reset_value()
         post_open.update_scene()
         post_open.update_layers()


### PR DESCRIPTION
## 관련 링크
[티켓](https://carpenstreet.atlassian.net/browse/SWTASK-359?atlOrigin=eyJpIjoiNDE1MjI1NDBiMTZlNDBiM2E1MGNlOTMzOWNiNTIxMjQiLCJwIjoiaiJ9)

## 발제/내용

### 파일 명 변경

- 고품질 렌더 중간에 `_HQ_` 넣기
- 오려내기 렌더
  - 오려내기 대상 - `_snipped_objects`
  - 전체 - `_snipped_full`
- 빠른 렌더 - `_quick`

### 빠른 렌더 폴더 선택 후 렌더하도록 변경
- Acon3dRenderDirOperator 를 상속하도록 변경

### 첫 렌더 진입 시 선택하는 폴더의 기본명 변경
- 폴더 명에 씬 추가하는 작업 제거
- 디폴트 폴더의 이름을 프로젝트 이름으로 하고, 없다면 씬 이름으로 하도록 변경함

### window_manager 에 render_default_path 를 추가
- 첫 렌더 후에는 render_default_path 에 선택한 폴더명을 저장하여 같은 프로젝트에서는 렌더 대상 파일을 열 때 항상 같은 폴더를 열도록 수정

### Render Queue 변경
- 빠른 렌더, 스닙 렌더도 렌더 타입으로 추가하여 Render Queue 에 넘겨줌
- 그에 따라 많아진 렌더 타입 관리 및 상수화를 위해 Enum RenderType 생성
- Render Queue 의 원소로 들어가는 Tuple의 순서를 (Scene Name, Scene, Render Type) => (Scene, Render Type, Scene Name) 로 변경
  - Scene, Render Type 이 항상 들어가고, Scene Name은 Optional 하기 때문

### 기타 작업
- prepare_queue - 추상 메서드로 변경하여 상속받은 클래스에서 무조건 구현하도록 함
- 주석 추가
- 명확한 의미를 위해 qitem 으로 사용하던 부분을 scene 으로 변경