### PR TITLE
SWTASK-419 macOS 시스템 일본어 지원 추가

### DIFF
--- a/release/darwin/ABLER.app/Contents/Info.plist
+++ b/release/darwin/ABLER.app/Contents/Info.plist
@@ -86,6 +86,7 @@
     <array>
         <string>en</string>
         <string>ko</string>
+        <string>ja</string>
     </array>
     <key>SUPublicEDKey</key>
     <string>${SPARKLE_PUBLIC_ED_KEY}</string>


### PR DESCRIPTION
## 관련 링크
[티켓](https://carpenstreet.atlassian.net/browse/SWTASK-419?atlOrigin=eyJpIjoiMjdiODU1MzJmYTE5NDk3MWE0NjFjZTE3NDc4YTFiNWUiLCJwIjoiaiJ9)

## 대응

- macOS 시스템 및 스파클의 일본어 지원을 위해 info.plist 를 수정하였습니다.