### PR TITLE
SWTASK-427 툰쉐이딩이 된 코니룸으로 UndoStack 초기화하도록 작업

### DIFF
--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -86,6 +86,8 @@ def delayed_load_handler():
         shadow.setup_clear_shadow()
         render.setup_background_images_compositor()
         materials_setup.apply_ACON_toon_style()
+        # blender undostack에 현재 상태의 스냅샷을 초기원소로 넣어준다.
+        bpy.context.window_manager.init_undostack()
         for scene in bpy.data.scenes:
             scene.view_settings.view_transform = "Standard"
         # 키맵이 ABLER로 세팅되어있는지 확인하고, 아닐 경우 세팅을 바로잡아줌

--- a/source/blender/blenkernel/BKE_undo_system.h
+++ b/source/blender/blenkernel/BKE_undo_system.h
@@ -186,7 +186,7 @@ void BKE_undosys_stack_destroy(UndoStack *ustack);
 void BKE_undosys_stack_clear(UndoStack *ustack);
 void BKE_undosys_stack_clear_active(UndoStack *ustack);
 bool BKE_undosys_stack_has_undo(const UndoStack *ustack, const char *name);
-void BKE_undosys_stack_init_from_main(UndoStack *ustack, struct Main *bmain);
+void BKE_undosys_stack_init_from_main(UndoStack *ustack, struct Main *bmain, bool from_abler);
 void BKE_undosys_stack_init_from_context(UndoStack *ustack, struct bContext *C);
 UndoStep *BKE_undosys_stack_active_with_type(UndoStack *ustack, const UndoType *ut);
 UndoStep *BKE_undosys_stack_init_or_active_with_type(UndoStack *ustack, const UndoType *ut);

--- a/source/blender/blenkernel/intern/undo_system.c
+++ b/source/blender/blenkernel/intern/undo_system.c
@@ -345,20 +345,19 @@ static bool undosys_stack_push_main(UndoStack *ustack, const char *name, struct 
   BLI_assert(ustack->step_init == NULL);
   CLOG_INFO(&LOG, 1, "'%s'", name);
 
-  /* Toon Shading 작업이 언두되지 않게 하기 위해 original file을 언두스택에 등록하지 않는다.
   bContext *C_temp = CTX_create();
   CTX_data_main_set(C_temp, bmain);
   eUndoPushReturn ret = BKE_undosys_step_push_with_type(
       ustack, C_temp, name, BKE_UNDOSYS_TYPE_MEMFILE);
   CTX_free(C_temp);
-   */
-  return ((1 << 0) & UNDO_PUSH_RET_SUCCESS);
+  return (ret & UNDO_PUSH_RET_SUCCESS);
 }
 
-void BKE_undosys_stack_init_from_main(UndoStack *ustack, struct Main *bmain)
-{
+void BKE_undosys_stack_init_from_main(UndoStack *ustack, struct Main *bmain, bool from_abler) {
   UNDO_NESTED_ASSERT(false);
-  undosys_stack_push_main(ustack, IFACE_("Original"), bmain);
+  if (from_abler) {
+    undosys_stack_push_main(ustack, IFACE_("Original"), bmain);
+  }
 }
 
 /* called after 'BKE_undosys_stack_init_from_main' */

--- a/source/blender/makesrna/intern/rna_wm_api.c
+++ b/source/blender/makesrna/intern/rna_wm_api.c
@@ -92,6 +92,13 @@ static void WM_set_fileselect_title(struct wmWindowManager *wm, int value)
   WM_set_abler_fileViewTitle(value);
 }
 
+void WM_insert_original_into_undostack(struct bContext *C)
+{
+  wmWindowManager *wm = CTX_wm_manager(C);
+  Main *bmain = CTX_data_main(C);
+  BKE_undosys_stack_init_from_main(wm->undo_stack, bmain, true);
+}
+
 float WM_get_progress(struct bContext *C) {
   Main *bmain = CTX_data_main(C);
   wmWindowManager *wm = CTX_wm_manager(C);
@@ -844,6 +851,12 @@ void RNA_api_wm(StructRNA *srna)
   RNA_def_function_ui_description(func, "Set fileselect title");
   parm = RNA_def_enum(func, "title_enum", file_view_title_items, 0, "title enum", "title enum for file selector");
   RNA_def_parameter_flags(parm, 0, PARM_REQUIRED);
+
+  func = RNA_def_function(srna, "init_undostack", "WM_insert_original_into_undostack");
+  RNA_def_function_ui_description(
+      func,
+      "Init ABLER undostack");
+  RNA_def_function_flag(func, FUNC_NO_SELF | FUNC_USE_CONTEXT);
 
   func = RNA_def_function(srna, "get_progress", "WM_get_progress");
   RNA_def_function_ui_description(

--- a/source/blender/windowmanager/intern/wm_files.c
+++ b/source/blender/windowmanager/intern/wm_files.c
@@ -753,7 +753,7 @@ static void wm_file_read_post(bContext *C, const struct wmFileReadPost_Params *p
       else {
         BKE_undosys_stack_clear(wm->undo_stack);
       }
-      BKE_undosys_stack_init_from_main(wm->undo_stack, bmain);
+      BKE_undosys_stack_init_from_main(wm->undo_stack, bmain, false);
       BKE_undosys_stack_init_from_context(wm->undo_stack, C);
     }
   }


### PR DESCRIPTION
## 발제/내용
언두스택 초기원소 제거작업의 사이드이펙트를 막기위한 작업
발견된 사례로는, 실행후 가만히 있으면 오토세이브 로직 작동시마다 언두스택이 비어서 warning이 발생함. 
(기존 블렌더 로직은 오토세이브마다 언두스택 가장 위의 메모리덤프를 내려버리는데, 스택이 비어있을리 없어서 심각한 상황으로 판단해서 경고한것)

## 대응
* 기존의 언두스택 로직 복구
* 초기 로딩시, 툰쉐이딩이 적용된 코니룸을 undo_stack에 넣어주는 로직 추가
