### PR TITLE
SWTASK-416 일문 번역 관련 검수 내용 반영

### DIFF
--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -86,13 +86,16 @@ class Acon3DVanillarBlenderWarning(BlockingModalOperator):
         box.label(text="Information", icon="INFO")
         row1 = box.row()
         row1.label(
-            text="Shader node changes may occur when working in abler, and this is at your own risk."
+            text="Shader node changes may occur when working in ABLER, and this is at your own risk.",
+            text_ctxt="abler",
         )
         row2 = box.row()
         col = row2.column()
-        col.operator("acon3d.close_blocking_modal_continue", text="Continue")
+        col.operator(
+            "acon3d.close_blocking_modal_continue", text="Continue", text_ctxt="abler"
+        )
         col = row2.column()
-        col.operator("acon3d.close_abler", text="Quit")
+        col.operator("acon3d.close_abler", text="Quit", text_ctxt="abler")
 
 
 class Acon3DWarningContiuue(CloseBlockingModalOperator):

--- a/source/blender/editors/interface/interface.c
+++ b/source/blender/editors/interface/interface.c
@@ -7127,7 +7127,7 @@ void UI_but_string_info_get(bContext *C, uiBut *but, ...)
           MenuType *mt = UI_but_menutype_get(but);
           if (mt) {
             if (type == BUT_GET_RNA_LABEL) {
-              tmp = BLI_strdup(mt->label);
+              tmp = BLI_strdup(CTX_TIP_(mt->translation_context, mt->label));
             }
             else {
               /* Not all menus are from Python. */
@@ -7157,7 +7157,7 @@ void UI_but_string_info_get(bContext *C, uiBut *but, ...)
           PanelType *pt = UI_but_paneltype_get(but);
           if (pt) {
             if (type == BUT_GET_RNA_LABEL) {
-              tmp = BLI_strdup(pt->label);
+              tmp = BLI_strdup(CTX_TIP_(pt->translation_context, pt->label));
             }
             else {
               /* Not all panels are from Python. */


### PR DESCRIPTION
## 관련 링크
[링크](https://carpenstreet.atlassian.net/browse/SWTASK-416)

## 발제/내용

- [번역 누락 추가](https://github.com/carpenstreet/blender-translations/pull/60) 를 위한 에이블러 코드 수정

## 대응

### 어떤 조치를 취했나요?

- 블랜더에서 저장한 파일 오픈시 에러 구문 번역을 위한 `text_ctxt="abler"` 추가
- 파일 브라우저 헤더에서 번역 안되는 에러
    - 블렌더 3.2.2 버전에선 번역 안되고 3.3.0 버전에서 번역이 되므로 그 사이 commit 내용들 비교해서 에러 해결 코드 추가
    - https://archive.blender.org/developer/D15417 참조