### PR TITLE
조명기능 사용성 개선

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -340,16 +340,16 @@ class AconLight(bpy.types.PropertyGroup):
     energy: bpy.props.FloatProperty(
         name="",
         description="Adjust light energy",
-        default=10.0,
+        default=5.0,
         min=0,
-        max=1000.0,
+        max=100.0,
         update=change_light_data,
     )
 
     diffuse_factor: bpy.props.FloatProperty(
         name="",
         description="Adjust light diffuse",
-        default=1.0,
+        default=5.0,
         min=0,
         max=100.0,
         update=change_light_data,
@@ -758,10 +758,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
 
     lights: bpy.props.CollectionProperty(type=AconLight)
     light_index: bpy.props.IntProperty(
-        name="",
-        min=0,
-        default=0,
-        update=scenes.change_ui_to_show_selected_light
+        name="", min=0, default=0, update=scenes.change_ui_to_show_selected_light
     )
 
 

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -33,6 +33,7 @@ bl_info = {
 import bpy
 from ..lib.tracker import tracker
 
+
 class Acon3dStylesPanel(bpy.types.Panel):
     bl_idname = "ACON_PT_Styles"
     bl_label = "Styles"
@@ -130,6 +131,7 @@ class SunlightPanel(bpy.types.Panel):
 class LIGHT_UL_List(bpy.types.UIList):
     bl_idname = "LIGHT_UL_List"
     bl_description = "Click to select a light"
+
     def __init__(self):
         super().__init__()
         self.use_filter_sort_reverse = True
@@ -182,15 +184,30 @@ class LightPanel(bpy.types.Panel):
 
             # PointLight 생성버튼
             col = row.column()
-            col.operator(AddPointLightOperator.bl_idname, text="Point", text_ctxt="abler", icon="LIGHT_POINT")
+            col.operator(
+                AddPointLightOperator.bl_idname,
+                text="Point",
+                text_ctxt="abler",
+                icon="LIGHT_POINT",
+            )
 
             # SpotLight 생성버튼
             col = row.column()
-            col.operator(AddSpotLightOperator.bl_idname, text="Spot", text_ctxt="abler", icon="LIGHT_SPOT")
+            col.operator(
+                AddSpotLightOperator.bl_idname,
+                text="Spot",
+                text_ctxt="abler",
+                icon="LIGHT_SPOT",
+            )
 
             # AreaLight 생성버튼
             col = row.column()
-            col.operator(AddAreaLightOperator.bl_idname, text="Area", text_ctxt="abler", icon="LIGHT_AREA")
+            col.operator(
+                AddAreaLightOperator.bl_idname,
+                text="Area",
+                text_ctxt="abler",
+                icon="LIGHT_AREA",
+            )
 
             row = layout.row(align=True)
             col = row.column()
@@ -216,12 +233,6 @@ class LightPanel(bpy.types.Panel):
                 row.prop(light, "color", text="Color", slider=True)
                 row = layout.row(align=True)
                 row.prop(light, "energy", text="Energy", slider=True)
-                row = layout.row(align=True)
-                row.prop(light, "diffuse_factor", text="Diffuse", slider=True)
-                row = layout.row(align=True)
-                row.prop(light, "specular_factor", text="Specular", slider=True)
-                row = layout.row(align=True)
-                row.prop(light, "volume_factor", text="Volume", slider=True)
 
 
 class AddLightOperatorBase(bpy.types.Operator):
@@ -242,6 +253,7 @@ class AddLightOperatorBase(bpy.types.Operator):
             name="ACON_light", type=self.light_type
         )
         acon_light_data.energy = 10
+        acon_light_data.diffuse_factor = 5
 
         # object 생성
         acon_light: Object = bpy.data.objects.new(acon_light_data.name, acon_light_data)


### PR DESCRIPTION
## 발제/내용
조명기능에서 diffuse(난반사), specular(반사), volume(볼륨 : 불, 안개 같은 물체뚫는 정도)
가 에이블러 툰쉐이더에서 사실상 효과가 거의 없음

## 대응
난반사만 디폴트값을 설정해주고, 색상과 에너지만으로 컨트롤 하도록 사용성을 개선함.
1. 난반사 디폴트값 수정 
2. 난반사, 반사, 볼륨 필드 제거

## 수정 후 최소강도, 최대 강도의 조명 예시

![스크린샷 2023-06-23 오전 10 25 04](https://github.com/carpenstreet/blender/assets/130434011/af6f5691-d5b9-4c55-868d-fe9fa95c9455)

![스크린샷 2023-06-23 오전 10 25 09](https://github.com/carpenstreet/blender/assets/130434011/ddf52955-c5e2-4d48-8e8c-e5de5cf8e89b)
