### PR TITLE
SWTASK-485 퀵 렌더 2번 이상 실행 시 이미지를 덮어쓰는 오류

### DIFF
--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -347,7 +347,8 @@ class Acon3dRenderDirOperator(Acon3dRenderOperator, AconImportHelper):
                     bpy.app.timers.register(self.render_handler, first_interval=0.01)
                 else:
                     if render_type == RenderType.quick:
-                        # quick render 에서는 핸들러가 실행되지 않음
+                        # render.opengl 의 경우 pre_render, post_render 가 호출되지 않아서 직접 호출
+                        # TODO 오퍼레이터 분리
                         self.pre_render(None, None)
                         bpy.ops.render.opengl("INVOKE_DEFAULT", write_still=True)
                         self.post_render(None, None)

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -346,9 +346,15 @@ class Acon3dRenderDirOperator(Acon3dRenderOperator, AconImportHelper):
                 if context.window_manager.progress_prop.is_loaded:
                     bpy.app.timers.register(self.render_handler, first_interval=0.01)
                 else:
-                    bpy.ops.render.render(
-                        "INVOKE_DEFAULT", write_still=self.write_still
-                    )
+                    if render_type == RenderType.quick:
+                        # quick render 에서는 핸들러가 실행되지 않음
+                        self.pre_render(None, None)
+                        bpy.ops.render.opengl("INVOKE_DEFAULT", write_still=True)
+                        self.post_render(None, None)
+                    else:
+                        bpy.ops.render.render(
+                            "INVOKE_DEFAULT", write_still=self.write_still
+                        )
 
         return {"PASS_THROUGH"}
 
@@ -371,8 +377,6 @@ class Acon3dRenderQuickOperator(Acon3dRenderDirOperator):
     def prepare_queue(self, context):
         for obj in context.selected_objects:
             obj.select_set(False)
-
-        bpy.ops.render.opengl("INVOKE_DEFAULT", write_still=True)
 
         self.render_queue.append((context.scene, RenderType.quick))
 


### PR DESCRIPTION
## 관련 링크
[티켓](https://carpenstreet.atlassian.net/jira/software/c/projects/SWTASK/boards/22?modal=detail&selectedIssue=SWTASK-485&assignee=63c78e769d59ec705fec7f44)

## 발제/내용

- 퀵렌더를 2번 이상 실행하는 경우, 기존 이미지를 덮어씌우면서 같은 이미지가 두 장 생성되는 오류가 발생함

## 대응

### 어떤 조치를 취했나요?

- modal 함수 내에서 quick 렌더만 별개로 분기처리하여 render.opengl, pre_render, post_render 함수를 실행시켜줌

## TODO

- 위 방법이 비효율적이라 리팩토링 시 핸들러를 사용하는 렌더와 사용하지 않는 렌더를 나누는 것이 좋아보임