### PR TITLE
SWTASK-428 obj 존재여부 확인 서순 변경

### DIFF
--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -100,9 +100,9 @@ class GroupNavigationManager:
 
     def go_top(self):
         obj = bpy.context.active_object
-        self._check_and_clear_visited_stack(obj)
         if not obj:
             return
+        self._check_and_clear_visited_stack(obj)
         while obj.parent:
             self._check_and_put_obj_in_visited_stack(obj)
             obj = obj.parent
@@ -112,9 +112,9 @@ class GroupNavigationManager:
 
     def go_up(self):
         obj = bpy.context.active_object
-        self._check_and_clear_visited_stack(obj)
         if not obj:
             return
+        self._check_and_clear_visited_stack(obj)
         if obj.parent:
             with self._programmatic_selection_scope():
                 self._check_and_put_obj_in_visited_stack(obj)
@@ -123,6 +123,8 @@ class GroupNavigationManager:
 
     def go_down(self):
         obj = bpy.context.active_object
+        if not obj:
+            return
         self._check_and_clear_visited_stack(obj)
         if self._selection_visited_stack:
             with self._programmatic_selection_scope():
@@ -137,6 +139,8 @@ class GroupNavigationManager:
 
     def go_bottom(self):
         obj = bpy.context.active_object
+        if not obj:
+            return
         self._check_and_clear_visited_stack(obj)
         if self._selection_visited_stack:
             with self._programmatic_selection_scope():


### PR DESCRIPTION
## 관련 링크
[Jira 티켓 링크](https://carpenstreet.atlassian.net/browse/SWTASK-428)

## 발제/내용

- obj가 Nonetype인데, obj에 대한 필드에 접근하여, 에러가 발생했었음. [에러링크](https://carpenstreet-np.sentry.io/share/issue/1c69fde07f294b57b2e352e4da8b4011/)

## 대응

### 어떤 조치를 취했나요?

- obj를 소비하는 함수가 if not obj 문 위에 있어서 위치를 옮겨줌. 
- 비슷한 결의 함수들 중에서 방어코드가 없는 함수들에 방어코드를 추가함.