### PR TITLE
[SWTASK-475] 레이어 토글 속도 개선

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -167,7 +167,7 @@ class CollectionLayerExcludeProperties(bpy.types.PropertyGroup):
         def get_parent_value(obj):
             cur = obj.parent
             while cur:
-                if cur.hide_viewport:
+                if cur.hide_get():
                     return False
                 cur = cur.parent
             return True

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -184,8 +184,7 @@ class CollectionLayerExcludeProperties(bpy.types.PropertyGroup):
                         value = False
                         break
 
-            obj.hide_viewport = not value
-            obj.hide_render = not value
+            obj.hide_set(not value)
 
             for o in obj.children:
                 update_objects(o, value)

--- a/release/scripts/startup/abler/lib/layers.py
+++ b/release/scripts/startup/abler/lib/layers.py
@@ -79,8 +79,7 @@ def handle_layer_visibility_on_scene_change(oldScene, newScene):
                     new_value = False
                     break
 
-            obj.hide_viewport = not new_value
-            obj.hide_render = not new_value
+            obj.hide_set(not new_value)
 
         if new_lock is not None:
             if not new_lock:


### PR DESCRIPTION
## 관련 링크
[링크](https://carpenstreet.atlassian.net/browse/SWTASK-475)

## 발제/내용

- 레이어 토글 속도 개선 작업
- hide_set()으로 설정하는거 외에 당장은 좋은 방법이 없어(카드 참고) 일차적으로 개선

## 대응

### 어떤 조치를 취했나요?

- obj.hide_set으로 변경