### PR TITLE
3D 커서 기반의 조명 생성 기능 추가

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -524,7 +524,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
 
     spawn_light_on_cursor: bpy.props.BoolProperty(
         name="",
-        description="Lights",
+        description="Spawn light on 3D cursor",
         default=True,
     )
 

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -522,6 +522,12 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         default=True,
     )
 
+    spawn_light_on_cursor: bpy.props.BoolProperty(
+        name="",
+        description="Lights",
+        default=True,
+    )
+
     toggle_shadow_shading: bpy.props.BoolProperty(
         name="",
         description="Express shadow and shading",

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -276,6 +276,7 @@ class AddLightOperatorBase(bpy.types.Operator):
         self.scene.collection.objects.link(light)
         item = self.scene.ACON_prop.lights.add()
         item.obj = light
+        self.scene.ACON_prop.light_index = len(self.scene.ACON_prop.lights) - 1
 
         # select just created light
         bpy.ops.object.select_all(action="DESELECT")

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -177,11 +177,19 @@ class LightPanel(bpy.types.Panel):
             layout.use_property_decorate = False  # No animation.
             layout.use_property_split = True
             row = layout.row(align=True)
+
             # Add Light
-            row.label(text="Add Light")
+            col = row.column(align=True)
+            col.label(text="Add Light")
+            col = row.column(align=True)
+            col.prop(
+                context.scene.ACON_prop,
+                "spawn_light_on_cursor",
+                toggle=1,
+                icon="CURSOR",
+            )
 
             row = layout.row(align=True)
-
             # PointLight 생성버튼
             col = row.column()
             col.operator(
@@ -236,7 +244,7 @@ class LightPanel(bpy.types.Panel):
 
 
 class AddLightOperatorBase(bpy.types.Operator):
-    bl_options = {"REGISTER"}
+    bl_options = {"REGISTER", "UNDO"}
     bl_translation_context = "abler"
     light_type = "LIGHT_BASE"
     scene: bpy.types.Scene
@@ -257,6 +265,10 @@ class AddLightOperatorBase(bpy.types.Operator):
 
         # object 생성
         acon_light: Object = bpy.data.objects.new(acon_light_data.name, acon_light_data)
+
+        if self.scene.ACON_prop.spawn_light_on_cursor:
+            acon_light.location = bpy.context.scene.cursor.location
+
         return acon_light
 
     def execute(self, context):

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -276,6 +276,11 @@ class AddLightOperatorBase(bpy.types.Operator):
         self.scene.collection.objects.link(light)
         item = self.scene.ACON_prop.lights.add()
         item.obj = light
+
+        # select just created light
+        bpy.ops.object.select_all(action="DESELECT")
+        light.select_set(True)
+
         tracker.add_light()
         return {"FINISHED"}
 
@@ -325,7 +330,7 @@ class RemoveLightOperator(bpy.types.Operator):
         scene.ACON_prop.lights.remove(index)
 
         if index > 0:
-            index = index - 1
+            scene.ACON_prop.light_index = index - 1
 
         tracker.remove_light()
         return {"FINISHED"}


### PR DESCRIPTION
1. 아이콘 토글을 이용해서 3D 커서 좌표에 조명 생성하는 기능 추가
(만약 토글 해제 되어 있다면, 월드좌표계 원점에 생성됨)

2. 조명생성 오퍼레이션 언두 지원
![스크린샷 2023-07-26 오후 4 48 27](https://github.com/carpenstreet/blender/assets/130434011/e103df3a-af64-4ff9-9f11-64678c36ecc1)

