### PR TITLE
SWTASK-580 퀵렌더시 가이드라인이 보이는 현상 수정

### DIFF
--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -1,4 +1,4 @@
-release/scripts/startup/abler/export_tab/render_control.py# ##### BEGIN GPL LICENSE BLOCK #####
+# ##### BEGIN GPL LICENSE BLOCK #####
 #
 #  This program is free software; you can redistribute it and/or
 #  modify it under the terms of the GNU General Public License
@@ -222,8 +222,8 @@ class Acon3dRenderOperator(bpy.types.Operator):
         bpy.app.handlers.render_pre.append(self.pre_render)
         bpy.app.handlers.render_post.append(self.post_render)
         bpy.app.handlers.render_cancel.append(self.on_render_cancel)
-        bpy.app.handlers.render_post.append(self.show_guideline)
-        bpy.app.handlers.render_cancel.append(self.show_guideline)
+        bpy.app.handlers.render_post.append(self.show_guideline())
+        bpy.app.handlers.render_cancel.append(self.show_guideline())
 
         return self.prepare_queue(context)
 

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -203,6 +203,9 @@ class Acon3dRenderOperator(bpy.types.Operator):
         context.window_manager.fileselect_add(self)
         return {"RUNNING_MODAL"}
 
+    def show_guideline(self, context):
+        context.screen.areas[0].spaces[0].overlay.show_extras = True
+
     def execute(self, context):
         self.render_canceled = False
         self.rendering = False
@@ -216,9 +219,12 @@ class Acon3dRenderOperator(bpy.types.Operator):
         context.preferences.view.render_display_type = "NONE"
         context.window_manager.modal_handler_add(self)
 
+
         bpy.app.handlers.render_pre.append(self.pre_render)
-        bpy.app.handlers.render_post.append(self.post_render)
         bpy.app.handlers.render_cancel.append(self.on_render_cancel)
+        bpy.app.handlers.render_post.append(self.post_render)
+        bpy.app.handlers.render_post.append(self.show_guideline)
+        bpy.app.handlers.render_cancel.append(self.show_guideline)
 
         return self.prepare_queue(context)
 
@@ -293,6 +299,7 @@ class Acon3dRenderDirOperator(Acon3dRenderOperator, AconImportHelper):
                     message_1="Rendered images are saved in:",
                     message_2=self.filepath,
                 )
+
 
                 if self.show_on_completion:
                     open_directory(self.filepath)
@@ -384,9 +391,6 @@ class Acon3dRenderQuickOperator(Acon3dRenderDirOperator):
         return {"RUNNING_MODAL"}
 
     def modal(self, context, event):
-        if event.type == "TIMER":
-            if not self.render_queue or self.render_canceled is True:
-                context.screen.areas[0].spaces[0].overlay.show_extras = True
         return super().modal(context, event)
 
     def on_render_finish(self, context):

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -1,4 +1,4 @@
-# ##### BEGIN GPL LICENSE BLOCK #####
+release/scripts/startup/abler/export_tab/render_control.py# ##### BEGIN GPL LICENSE BLOCK #####
 #
 #  This program is free software; you can redistribute it and/or
 #  modify it under the terms of the GNU General Public License
@@ -219,10 +219,9 @@ class Acon3dRenderOperator(bpy.types.Operator):
         context.preferences.view.render_display_type = "NONE"
         context.window_manager.modal_handler_add(self)
 
-
         bpy.app.handlers.render_pre.append(self.pre_render)
-        bpy.app.handlers.render_cancel.append(self.on_render_cancel)
         bpy.app.handlers.render_post.append(self.post_render)
+        bpy.app.handlers.render_cancel.append(self.on_render_cancel)
         bpy.app.handlers.render_post.append(self.show_guideline)
         bpy.app.handlers.render_cancel.append(self.show_guideline)
 
@@ -299,7 +298,6 @@ class Acon3dRenderDirOperator(Acon3dRenderOperator, AconImportHelper):
                     message_1="Rendered images are saved in:",
                     message_2=self.filepath,
                 )
-
 
                 if self.show_on_completion:
                     open_directory(self.filepath)

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -322,10 +322,8 @@ class RemoveLightOperator(bpy.types.Operator):
         if index >= len(lights):
             return {"FINISHED"}
 
-        light_obj = scene.ACON_prop.lights[index].obj
-
         # 실제 오브젝트 제거 (data block 정리는 블렌더가 함)
-        if light_obj:
+        if light_obj := scene.ACON_prop.lights[index].obj:
             bpy.data.objects.remove(light_obj)
 
         # ACON_prop.lights 데이터 제거

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -325,7 +325,8 @@ class RemoveLightOperator(bpy.types.Operator):
         light_obj = scene.ACON_prop.lights[index].obj
 
         # 실제 오브젝트 제거 (data block 정리는 블렌더가 함)
-        bpy.data.objects.remove(light_obj)
+        if light_obj:
+            bpy.data.objects.remove(light_obj)
 
         # ACON_prop.lights 데이터 제거
         scene.ACON_prop.lights.remove(index)


### PR DESCRIPTION
퀵렌더시 발생하는 가이드라인 노출 현상을 수정함

* 렌더작업이 async로 이루어져 가이드라인 토글해야하는 정확한 타이밍 설정이 어려운 것을 확인함
* post_render 핸들러에 토글 작업을 추가함
* 기타 간단한 조명삭제기능 방어로직 추가